### PR TITLE
docs: start new readme, with basic setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,34 +1,70 @@
-# Admin tool for de-deduping artists
+# Forque
 
-This experiment from Hackathon 2022 provides an alternative for handling specialized one-off admin functionality.
+A home for admin apps
 
-This app currently houses one such specialized tool: a fresh take on **artist de-duping**.
+## Meta
 
-The app provides the following stack:
-
-- **Next.js** project for handling SSR, server- and client-side-routing, api endpoints etc
-- **Gravity** authentication, including 2FA
-- **SWR** data fetching hooks for **Gravity and Metaphysics**
-- **Storybook** for visual component development
-- **Jest** and **React Testing Library** for unit tests
-- **Cypress** for end-to-end tests
-- **Tailwind** for styling
-- **Palette tokens** for use with Tailwind: typography, color, space, breakpoints.
-- DevX: Typescript, ESLint, Prettier, lint-staged, commitlint
-
+- **State:** development
+- **Staging:** [https://forque.stg.artsy.systems](https://forque.stg.artsy.systems)
+  - [Kubernetes](https://kubernetes.stg.artsy.systems/#/search?q=force&namespace=default)
+- **Production:** [https://forque.prd.artsy.systems](https://forque.prd.artsy.systems)
+  - [Kubernetes](https://kubernetes.prd.artsy.systems/#/search?q=force&namespace=default)
+- **GitHub:** [https://github.com/artsy/forque](https://github.com/artsy/forque)
+- **Deployment:**
+  - PRs from feature branches → main will automatically deploy to staging
+  - PRs from staging → release will automatically deploy to production. ([Start a deploy...](https://github.com/artsy/forque/compare/release...staging?expand=1))
+- **Point People:** TBD
 
 ## Setup
-
-Install dependencies and setup config values:
-
-```
-./scripts/setup.sh
-yarn dev
-```
 
 Visit your local development server at http://localhost:3000
 
 ## Configuration
 
+## Setup
+
+Clone the repo:
+
+```sh
+git clone git@github.com:artsy/forque.git
+cd forque
+```
+
+Install dependencies and setup config values:
+
+```
+./scripts/setup.sh
+```
+
 Defaults are in `.env.development`. Sensitive overrides are copied from S3 to `.env.local`. Personal overrides can be provided in a `.env.development.local` file.
 
+Run unit tests:
+
+```
+yarn test
+```
+
+Start a development server:
+
+```
+yarn dev
+```
+
+Start Storybook:
+
+```
+yarn storybook
+```
+
+## Troubleshooting
+
+If you get a `Only absolute URLs are supported` upon login this may mean that you don't have a properly configured env file. Be sure to follow the setup steps above.
+
+If you get a `Unauthorized: invalid client_id` upon login this may mean that you haven't configured the correct app id and app secret in your env file. The appropriate ClientApplication credentials can be found in Gravity.
+
+## About
+
+Forque originally began as a Hackathon project in January 2022. It aims to
+provide a typical Artsy frontend stack for creating modern admin UIs.
+
+It is built on the [Next.js](https://nextjs.org) framework.

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "nextbookwind",
+  "name": "forque",
   "private": true,
   "scripts": {
     "build-storybook": "build-storybook",
@@ -10,7 +10,8 @@
     "prepare": "husky install",
     "start": "next start",
     "storybook": "start-storybook -p 6006",
-    "type-check": "tsc"
+    "test": "jest",
+    "type-check": "tsc --noEmit"
   },
   "prettier": {
     "bracketSpacing": true,


### PR DESCRIPTION
I expect this to evolve based on the work over in #5 and beyond, but this gets us [a cleaner slate](https://github.com/artsy/forque/blob/c5fc296c0d92d71e5625d92f55e5c8f024bb906d/README.md) to start from.
