### PR TITLE
fix(dedupe): post-Palette style regressions 

### DIFF
--- a/src/components/GlobalNav.tsx
+++ b/src/components/GlobalNav.tsx
@@ -18,12 +18,12 @@ export const GlobalNav: React.FC<Props> = ({ user }) => {
 const LoggedOut = () => (
   <nav className="flex justify-end bg-black100">
     <Link href="/">
-      <a className="inline-block p-2 font-bold text-white100 hover:bg-black60">
+      <a className="no-underline inline-block p-2 font-bold text-white100 hover:bg-black60 hover:text-white100">
         Home
       </a>
     </Link>
     <Link href="/login">
-      <a className="inline-block p-2 font-bold text-white100 hover:bg-black60">
+      <a className="no-underline inline-block p-2 font-bold text-white100 hover:bg-black60 hover:text-white100">
         Login
       </a>
     </Link>
@@ -33,17 +33,17 @@ const LoggedOut = () => (
 const LoggedIn = () => (
   <nav className="flex justify-end bg-black100">
     <Link href="/">
-      <a className="inline-block p-2 font-bold text-white100 hover:bg-black60">
+      <a className="no-underline inline-block p-2 font-bold text-white100 hover:bg-black60 hover:text-white100">
         Home
       </a>
     </Link>
     <Link href="/artists/dedupe">
-      <a className="inline-block p-2 font-bold text-white100 hover:bg-black60">
+      <a className="no-underline inline-block p-2 font-bold text-white100 hover:bg-black60 hover:text-white100">
         Dedupe Artists
       </a>
     </Link>
     <Link href="/api/artsy-auth/logout">
-      <a className="inline-block p-2 font-bold text-white100 hover:bg-black60">
+      <a className="no-underline inline-block p-2 font-bold text-white100 hover:bg-black60 hover:text-white100">
         Logout
       </a>
     </Link>

--- a/src/pages/artists/dedupe/components/list/ArtistList.tsx
+++ b/src/pages/artists/dedupe/components/list/ArtistList.tsx
@@ -28,7 +28,7 @@ const Artist: React.FC<{ artist: RecentArtist }> = ({ artist }) => {
 
   return hasDupes ? (
     <Link href={`/artists/dedupe/${artist.slug}`}>
-      <a className="group p-1 rounded-md">
+      <a className="no-underline group p-1 rounded-md">
         <div className="font-bold group-hover:underline">{artist.name}</div>
         <Count n={artist.counts.duplicates} />
         <div className="text-black30 text-md">{ago}</div>
@@ -36,7 +36,7 @@ const Artist: React.FC<{ artist: RecentArtist }> = ({ artist }) => {
     </Link>
   ) : (
     <Link href={`/artists/dedupe/${artist.slug}`}>
-      <a className="group p-1">
+      <a className="no-underline group p-1">
         <div className="text-black60 group-hover:underline">{artist.name}</div>
         <div className="text-black30 text-md">{ago}</div>
       </a>


### PR DESCRIPTION
The installation of Palette in 7b30faf clobbered a few global styles for the existing Tailwind-styled components. This is a quick fix for that (though of course re-styling this with Palette would also be totally legit).

|Before|After|
|---|---|
|<img width="500" alt="Screen Shot 2022-03-25 at 3 05 34 PM" src="https://user-images.githubusercontent.com/140521/160185665-2031affe-6893-44e4-b3ed-ca1995e859e6.png">|<img width="500" alt="Screen Shot 2022-03-25 at 3 05 59 PM" src="https://user-images.githubusercontent.com/140521/160185687-bb4a8bb7-0c4e-4321-936e-b10c552c1729.png">|