### PR TITLE
fix: expose runtime config to client

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,5 +1,9 @@
 /** @type {import('next').NextConfig} */
 module.exports = {
+  publicRuntimeConfig: {
+    NEXT_PUBLIC_GRAVITY_URL: process.env.NEXT_PUBLIC_GRAVITY_URL,
+    NEXT_PUBLIC_METAPHYSICS_URL: process.env.NEXT_PUBLIC_METAPHYSICS_URL,
+  },
   compiler: {
     styledComponents: true
   },

--- a/src/lib/artsy-next-auth/hooks/gravity.ts
+++ b/src/lib/artsy-next-auth/hooks/gravity.ts
@@ -1,8 +1,11 @@
 import useSWR from "swr"
 import { useUser } from "./user"
+import getConfig from "next/config"
+
+const { publicRuntimeConfig } = getConfig()
 
 const gravityFetcher = async (path: string, accessToken: string) => {
-  const url = `${process.env.NEXT_PUBLIC_GRAVITY_URL}/api/v1/${path}`
+  const url = `${publicRuntimeConfig.NEXT_PUBLIC_GRAVITY_URL}/api/v1/${path}`
 
   const headers = {
     "Content-Type": "application/json",

--- a/src/lib/artsy-next-auth/hooks/metaphysics.ts
+++ b/src/lib/artsy-next-auth/hooks/metaphysics.ts
@@ -1,12 +1,15 @@
 import useSWR from "swr"
 import { useUser } from "./user"
+import getConfig from "next/config"
+
+const { publicRuntimeConfig } = getConfig()
 
 const metaphysicsFetcher = async (
   query: string,
   variables = {},
   accessToken: string
 ) => {
-  const url = `${process.env.NEXT_PUBLIC_METAPHYSICS_URL}/v2`
+  const url = `${publicRuntimeConfig.NEXT_PUBLIC_METAPHYSICS_URL}/v2`
 
   const response = await fetch(url, {
     method: "POST",


### PR DESCRIPTION
This properly exposes runtime env vars so they can be employed by client-side code, as [recommended here](https://www.saltycrane.com/blog/2021/04/buildtime-vs-runtime-environment-variables-nextjs-docker/#using-runtime-environment-variables-client-side-or-server-side).

