### PR TITLE
build: more experimentation with runtime env vars

### DIFF
--- a/src/pages/env/index.page.tsx
+++ b/src/pages/env/index.page.tsx
@@ -1,6 +1,7 @@
 import type { NextPage } from "next"
 import Head from "next/head"
 import getConfig from "next/config"
+import Link from "next/link"
 
 const { publicRuntimeConfig } = getConfig()
 
@@ -29,6 +30,10 @@ const Home: NextPage = () => {
         <br />
         NEXT_PUBLIC_METAPHYSICS_URL:{" "}
         {publicRuntimeConfig.NEXT_PUBLIC_METAPHYSICS_URL}
+        <br />
+        <Link href="/env/server">
+          <a>See also: server</a>
+        </Link>
       </div>
     </div>
   )

--- a/src/pages/env/server.page.tsx
+++ b/src/pages/env/server.page.tsx
@@ -1,6 +1,7 @@
 import type { NextPage } from "next"
 import Head from "next/head"
 import getConfig from "next/config"
+import Link from "next/link"
 
 const { publicRuntimeConfig } = getConfig()
 
@@ -31,6 +32,10 @@ const Home: NextPage = (props) => {
         {publicRuntimeConfig.NEXT_PUBLIC_METAPHYSICS_URL}
         <h2 className="mt-4 mb-2 text-lg">serverSideProps</h2>
         <pre>{JSON.stringify(props)}</pre>
+        <br />
+        <Link href="/env">
+          <a>See also: client</a>
+        </Link>
       </div>
     </div>
   )


### PR DESCRIPTION
Confirmed locally, running in a production-like way, that the runtime environment variables (from `publicRuntimeConfig`) are available if the initially loaded page was server-side rendered, but _not if the initially loaded page is client-side rendered_.

My steps:
```
yarn build
CLIENT_APPLICATION_ID=... CLIENT_APPLICATION_SECRET=... GRAVITY_URL=... METAPHYSICS_URL=... NEXT_PUBLIC_GRAVITY_URL=... NEXT_PUBLIC_METAPHYSICS_URL=... NODE_ENV=production yarn start
```
Then, visit `/env/server` and follow the `Link` to `/env` and back, and confirm that the public runtime variables are available. Start on `/env` (which is client-side), and follow the link to `/env/server` to confirm that they're _not_ available.
