### PR TITLE
fix(dedupe): force SSR, to make runtime config available

### DIFF
--- a/src/pages/artists/dedupe/index.page.tsx
+++ b/src/pages/artists/dedupe/index.page.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react"
 import { useMetaphysics } from "lib/artsy-next-auth"
 import { ArtistList, Skeleton } from "./components/list/ArtistList"
+import type { GetServerSideProps } from "next"
 
 const PER_PAGE = 36
 
@@ -89,4 +90,9 @@ export default function Page() {
       )}
     </div>
   )
+}
+
+export const getServerSideProps: GetServerSideProps = async () => {
+  // force SSR
+  return { props: {} }
 }


### PR DESCRIPTION
Follow up to https://github.com/artsy/forque/pull/21 as well as [this Slack comment](https://artsy.slack.com/archives/C0376CFU527/p1648405432752219?thread_ts=1648217677.423169&cid=C0376CFU527)

This adds a `getServerSideProps` to the dedupe app in order to force into SSR mode, which is what is required to [access the runtime config in the Next-blessed way](https://nextjs.org/docs/api-reference/next.config.js/runtime-configuration).
