### PR TITLE
fix(env): force landing page to be ssr, to load runtime env

### DIFF
--- a/src/pages/index.page.tsx
+++ b/src/pages/index.page.tsx
@@ -34,4 +34,9 @@ const Home: NextPage = () => {
   )
 }
 
+export const getServerSideProps = async () => {
+  // force SSR
+  return { props: {} }
+}
+
 export default Home


### PR DESCRIPTION
Follow-up to #21 and #22

Adding another forced SSR at the landing page, in the hopes that this correctly loads the runtime config ENV vars, and then makes it available to subsequent client-side navigations.

cc @joeyAghion @damassi 