### PR TITLE
chore(prettier): ignore generated folder

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,4 @@
 # Ignore artifacts:
 build
 coverage
+src/__generated__


### PR DESCRIPTION
I keep noticing weird prettier faffing on our generated queries on git pull, so this ignores that directory. 