### PR TITLE
feat(system): add SystemContext for system-level functions

### DIFF
--- a/src/hooks/useMutation.ts
+++ b/src/hooks/useMutation.ts
@@ -3,7 +3,7 @@ import {
   GraphQLTaggedNode,
   MutationParameters,
 } from "relay-runtime"
-import { useEnvironment } from "system/relay"
+import { useSystemContext } from "system/SystemContext"
 
 /**
  * Helper hook for writing mutations.
@@ -51,7 +51,7 @@ export const useMutation = <T extends MutationParameters>({
 }: {
   mutation: GraphQLTaggedNode
 }) => {
-  const relayEnvironment = useEnvironment()
+  const { relayEnvironment } = useSystemContext()
 
   const submitMutation = (props: {
     variables: T["variables"]
@@ -60,7 +60,7 @@ export const useMutation = <T extends MutationParameters>({
     const { variables = {}, rejectIf } = props
 
     return new Promise((resolve, reject) => {
-      commitMutation<T>(relayEnvironment!, {
+      commitMutation<T>(relayEnvironment, {
         mutation,
         variables,
         onError: reject,

--- a/src/pages/_app.page.tsx
+++ b/src/pages/_app.page.tsx
@@ -9,6 +9,7 @@ import { useEnvironment } from "system/relay/setupEnvironment"
 import { RelayEnvironmentProvider } from "react-relay"
 import { getUserFromCookie } from "system/artsy-next-auth/auth/user"
 import { NextApiRequest } from "next"
+import { SystemContextProvider } from "system/SystemContext"
 
 const { GlobalStyles } = injectGlobalStyles(`
   /* overrides and additions */
@@ -17,26 +18,33 @@ const { GlobalStyles } = injectGlobalStyles(`
 export default function MyApp({ Component, pageProps }: AppProps) {
   const environment = useEnvironment({
     initialRecords: pageProps.relayData,
-    user: pageProps.user,
+    user: pageProps.systemUser,
   })
 
   return (
-    <Theme theme="v3">
+    <SystemContextProvider
+      relayEnvironment={environment}
+      user={pageProps.systemUser}
+    >
       <RelayEnvironmentProvider environment={environment!}>
-        <GlobalStyles />
-        <ErrorBoundary>
-          <Layout user={pageProps.user}>
-            <Component {...pageProps} />
-          </Layout>
-        </ErrorBoundary>
+        <Theme theme="v3">
+          <GlobalStyles />
+          <ErrorBoundary>
+            <Layout user={pageProps.systemUser}>
+              <Component {...pageProps} />
+            </Layout>
+          </ErrorBoundary>
+        </Theme>
       </RelayEnvironmentProvider>
-    </Theme>
+    </SystemContextProvider>
   )
 }
 
 MyApp.getInitialProps = async (appContext: AppContext) => {
   const appProps = await App.getInitialProps(appContext)
-  const user = await getUserFromCookie(appContext.ctx.req as NextApiRequest)
-  appProps.pageProps.user = user
-  return { ...appProps }
+  const systemUser = await getUserFromCookie(
+    appContext.ctx.req as NextApiRequest
+  )
+  appProps.pageProps.systemUser = systemUser
+  return appProps
 }

--- a/src/system/SystemContext.tsx
+++ b/src/system/SystemContext.tsx
@@ -1,0 +1,29 @@
+import { createContext, useContext } from "react"
+import { Environment } from "relay-runtime"
+import { UserSessionData } from "./artsy-next-auth/auth/user"
+
+interface SystemContextProps {
+  relayEnvironment: Environment
+  user: UserSessionData | null
+}
+
+const SystemContext = createContext<SystemContextProps>({
+  relayEnvironment: null,
+  user: null,
+} as unknown as SystemContextProps)
+
+export const SystemContextProvider: React.FC<SystemContextProps> = ({
+  children,
+  ...contextValues
+}) => {
+  return (
+    <SystemContext.Provider value={contextValues}>
+      {children}
+    </SystemContext.Provider>
+  )
+}
+
+export const useSystemContext = () => {
+  const systemContext = useContext(SystemContext)
+  return systemContext
+}

--- a/src/system/relay/setupEnvironment.ts
+++ b/src/system/relay/setupEnvironment.ts
@@ -47,6 +47,6 @@ export function useEnvironment({
     } else {
       setupEnvironment({ initialRecords, user })
     }
-  }, [initialRecords, user])
+  }, [initialRecords, user]) as Environment
   return store
 }


### PR DESCRIPTION
This adds a system context, similar to force, where you can pull out commonly used things such as `user` and `relayEnvironment`, etc. I expect this to grow in time. 

This also fixes the missing headers for mutations; however this now yields a new error which I suspect is a MP level thing, or personal access thing (which is good!):

<img width="487" alt="Screen Shot 2022-03-29 at 2 30 20 PM" src="https://user-images.githubusercontent.com/236943/160711450-15cbafda-a76a-4f54-8bda-689734946b31.png">

