### PR TITLE
chore(system): move useSystemContext hook to /hooks

### DIFF
--- a/src/hooks/useMutation.ts
+++ b/src/hooks/useMutation.ts
@@ -3,7 +3,7 @@ import {
   GraphQLTaggedNode,
   MutationParameters,
 } from "relay-runtime"
-import { useSystemContext } from "system/SystemContext"
+import { useSystemContext } from "./useSystemContext"
 
 /**
  * Helper hook for writing mutations.

--- a/src/hooks/useSystemContext.ts
+++ b/src/hooks/useSystemContext.ts
@@ -1,0 +1,7 @@
+import { useContext } from "react"
+import { SystemContext } from "system/SystemContext"
+
+export const useSystemContext = () => {
+  const systemContext = useContext(SystemContext)
+  return systemContext
+}

--- a/src/system/SystemContext.tsx
+++ b/src/system/SystemContext.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext } from "react"
+import { createContext } from "react"
 import { Environment } from "relay-runtime"
 import { UserSessionData } from "./artsy-next-auth/auth/user"
 
@@ -7,7 +7,7 @@ interface SystemContextProps {
   user: UserSessionData | null
 }
 
-const SystemContext = createContext<SystemContextProps>({
+export const SystemContext = createContext<SystemContextProps>({
   relayEnvironment: null,
   user: null,
 } as unknown as SystemContextProps)
@@ -21,9 +21,4 @@ export const SystemContextProvider: React.FC<SystemContextProps> = ({
       {children}
     </SystemContext.Provider>
   )
-}
-
-export const useSystemContext = () => {
-  const systemContext = useContext(SystemContext)
-  return systemContext
 }


### PR DESCRIPTION
Moves the `useSystemContext` hook to /hooks with the rest of the... hooks 