### PR TITLE
chore: remove unused API endpoint

### DIFF
--- a/src/pages/api/status.ts
+++ b/src/pages/api/status.ts
@@ -1,5 +1,0 @@
-import type { NextApiRequest, NextApiResponse } from "next"
-
-export default function handler(req: NextApiRequest, res: NextApiResponse) {
-  res.status(200).json({ status: "OK" })
-}


### PR DESCRIPTION
This status API was added (https://github.com/artsy/forque/pull/5) for kubernetes's readiness probe, but didn't end up working compatibly with the reorg in https://github.com/artsy/forque/pull/6. Instead, we added a "static" status route in https://github.com/artsy/forque/pull/11, which I think is actually fine for readiness probe purposes (since it's not being requested through a CDN or any other caching server). This PR just removes the original status API.