### PR TITLE
fix(relay): Properly configure relay network

### DIFF
--- a/src/system/relay/setupEnvironment.ts
+++ b/src/system/relay/setupEnvironment.ts
@@ -45,7 +45,7 @@ export function useEnvironment({
     if (relayEnvironment) {
       return relayEnvironment
     } else {
-      setupEnvironment({ initialRecords, user })
+      return setupEnvironment({ initialRecords, user })
     }
   }, [initialRecords, user]) as Environment
   return store


### PR DESCRIPTION
Missed a `return`. 

Introduced in [here](https://github.com/artsy/forque/commit/6f36d49cf4bc68067750b5f97ffc111aa6dde48a#diff-4193debf105e2abbdd8b85f0506b326e908f5a9f47aeaa805191595afbb5e2c6L45) via my expansion of this logic to include a conditional, which led to us losing the implicit return, as it was originally setup. 

This error was only visible in code that uses Relay hooks, so wasn't spotted for most of yesterday due to us working within root routes. 


