### PR TITLE
fix(relay): yet again, properly initialize env

### DIFF
--- a/src/system/relay/setupEnvironment.ts
+++ b/src/system/relay/setupEnvironment.ts
@@ -42,11 +42,7 @@ export function useEnvironment({
   user,
 }: SetupEnvironmentProps = {}) {
   const store = useMemo(() => {
-    if (relayEnvironment) {
-      return relayEnvironment
-    } else {
-      return setupEnvironment({ initialRecords, user })
-    }
+    return setupEnvironment({ initialRecords, user })
   }, [initialRecords, user]) as Environment
   return store
 }


### PR DESCRIPTION
Realized that we no longer need this additional check as we're initializing our app with [a `SystemContextProvider`](https://github.com/artsy/forque/blob/main/src/pages/_app.page.tsx#L26-L29) which centralizes control of these bits. 