### PR TITLE
fix(dedupe): force ssr on subpage

### DIFF
--- a/src/pages/artists/dedupe/[slug].page.tsx
+++ b/src/pages/artists/dedupe/[slug].page.tsx
@@ -59,3 +59,6 @@ export default function Page() {
     )
   }
 }
+
+// HACK: force ssr
+export const getServerSideProps = () => ({ props: {} })

--- a/src/pages/artists/dedupe/index.page.tsx
+++ b/src/pages/artists/dedupe/index.page.tsx
@@ -1,7 +1,6 @@
 import { useState } from "react"
 import { useMetaphysics } from "system/artsy-next-auth"
 import { ArtistList, Skeleton } from "./components/list/ArtistList"
-import type { GetServerSideProps } from "next"
 
 const PER_PAGE = 36
 
@@ -92,7 +91,5 @@ export default function Page() {
   )
 }
 
-export const getServerSideProps: GetServerSideProps = async () => {
-  // force SSR
-  return { props: {} }
-}
+// HACK: force ssr
+export const getServerSideProps = () => ({ props: {} })


### PR DESCRIPTION
Adds the SSR hack to the second screen of the artist deduping app.

Interestingly the _symptom_ of not adding the hack seems to have changed — I got hit with a login prompt, but maybe that was expected cc @damassi @dzucconi 

<img width=400 src="https://user-images.githubusercontent.com/140521/161077732-169cfbb1-3d5c-4db3-a950-7d13b5c0ba85.gif" />

