### PR TITLE
fix(loader): cleanup

### DIFF
--- a/src/system/RouteLoadingBar.tsx
+++ b/src/system/RouteLoadingBar.tsx
@@ -5,12 +5,10 @@ export const RouteLoadingBar: React.FC = () => {
   return (
     <NextNProgress
       color={THEME_V3.colors.white100}
-      startPosition={Math.random() * 1}
       height={1}
       options={{
         easing: "ease-in-out",
-        speed: 700,
-        minimum: 0.5,
+        speed: 300,
         showSpinner: false,
       }}
     />


### PR DESCRIPTION
This cleans up the loader a bit, makes a bit faster. Noticed that double clicks between two pages can spazz it out. 