### PR TITLE
feat: Wire up the 3 basic user fields

### DIFF
--- a/data/schema.graphql
+++ b/data/schema.graphql
@@ -14140,6 +14140,8 @@ input UpdateUserMutationInput {
   clientMutationId: String
   email: String!
   id: String!
+  name: String!
+  phone: String!
 }
 
 type UpdateUserMutationPayload {

--- a/src/__generated__/UserIdQuery.graphql.ts
+++ b/src/__generated__/UserIdQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<1ce49d96bdb3d945afd73dc1823b3e0b>>
+ * @generated SignedSource<<8caf0e149afec46ab3e134d75b91867a>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -17,6 +17,7 @@ export type UserIdQuery$data = {
     readonly internalID: string;
     readonly email: string;
     readonly name: string;
+    readonly phone: string | null;
   } | null;
 };
 export type UserIdQuery = {
@@ -59,6 +60,13 @@ v4 = {
   "kind": "ScalarField",
   "name": "name",
   "storageKey": null
+},
+v5 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "phone",
+  "storageKey": null
 };
 return {
   "fragment": {
@@ -77,7 +85,8 @@ return {
         "selections": [
           (v2/*: any*/),
           (v3/*: any*/),
-          (v4/*: any*/)
+          (v4/*: any*/),
+          (v5/*: any*/)
         ],
         "storageKey": null
       }
@@ -102,6 +111,7 @@ return {
           (v2/*: any*/),
           (v3/*: any*/),
           (v4/*: any*/),
+          (v5/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -115,16 +125,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "3287b33d34e990acd84feb35370bb0c9",
+    "cacheID": "d6d83ddf682c75e38d40104d5170a44c",
     "id": null,
     "metadata": {},
     "name": "UserIdQuery",
     "operationKind": "query",
-    "text": "query UserIdQuery(\n  $userId: String!\n) {\n  user(id: $userId) {\n    internalID\n    email\n    name\n    id\n  }\n}\n"
+    "text": "query UserIdQuery(\n  $userId: String!\n) {\n  user(id: $userId) {\n    internalID\n    email\n    name\n    phone\n    id\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "c507fa571b2f86c82341853ee5cd7b7a";
+(node as any).hash = "5c577cfff7e36a791e0f9b1d2131ce80";
 
 export default node;

--- a/src/__generated__/useUpdateUserMutation.graphql.ts
+++ b/src/__generated__/useUpdateUserMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<d3966236ab28f421034ea3a74639947c>>
+ * @generated SignedSource<<743dd832cab099591c615478094a760f>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -13,6 +13,8 @@ export type UpdateUserMutationInput = {
   clientMutationId?: string | null;
   email: string;
   id: string;
+  name: string;
+  phone: string;
 };
 export type useUpdateUserMutation$variables = {
   input: UpdateUserMutationInput;

--- a/src/pages/users/[userId].page.tsx
+++ b/src/pages/users/[userId].page.tsx
@@ -29,6 +29,7 @@ const User: React.FC<UserProps> = ({ user }) => {
         initialValues={{
           name: user.name,
           email: user.email,
+          phoneNumber: user.phone || undefined,
         }}
         validationSchema={userValidationSchema}
         onSubmit={async (values) => {
@@ -38,6 +39,8 @@ const User: React.FC<UserProps> = ({ user }) => {
                 input: {
                   id: user.internalID,
                   email: values.email,
+                  name: values.name,
+                  phone: values.phoneNumber!,
                 },
               },
             })
@@ -85,6 +88,7 @@ export const getServerSideProps: GetServerSideProps = async (ctx) => {
           internalID
           email
           name
+          phone
         }
       }
     `,


### PR DESCRIPTION
Small PR but this sets up adding the laundry list of user fields. All I did here was look through the existing user query in MP and pick out the fields that appear in Torque and thus in Forque for a user. Turns out it was just name and phone that we're missing! There was priceRange too but I ended up bailing on that because it was confusing me - more chatter here:

https://artsy.slack.com/archives/C0376CFU527/p1648737219712459

Note that this PR will depend on https://github.com/artsy/metaphysics/pull/3926 so we'll want to merge that first.