### PR TITLE
feat(autocompletes): add standard autocompletes for artist and user

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -11,6 +11,9 @@ AWS_DEFAULT_REGION=us-east-1
 # Disable datadog tracing
 DATATDOG_APM_ENABLED=false
 
+# Allow-list src domains for next/image component
+ALLOWED_IMAGE_DOMAINS=d32dm0rphc51dk.cloudfront.net,d2v80f5yrouhh2.cloudfront.net
+
 ##########################
 # Available on client side
 ##########################

--- a/next.config.js
+++ b/next.config.js
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
-const { withSentryConfig } = require('@sentry/nextjs');
+const { withSentryConfig } = require("@sentry/nextjs")
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
@@ -23,9 +23,16 @@ const nextConfig = {
   sentry: {
     disableServerWebpackPlugin: true,
     disableClientWebpackPlugin: true,
-  }
+  },
+  images: {
+    domains: getImageDomains(),
+  },
+}
+
+function getImageDomains() {
+  return (process.env.ALLOWED_IMAGE_DOMAINS || "").split(/\s*,\s*/)
 }
 
 // Make sure adding Sentry options is the last code to run before exporting, to
 // ensure that your source maps include changes from all other Webpack plugins
-module.exports = withSentryConfig(nextConfig);
+module.exports = withSentryConfig(nextConfig)

--- a/src/components/autocomplete/ArtistAutocomplete.tsx
+++ b/src/components/autocomplete/ArtistAutocomplete.tsx
@@ -1,0 +1,68 @@
+import { useState } from "react"
+import {
+  AutocompleteInput,
+  AutocompleteInputOptionType,
+  AutocompleteInputProps,
+} from "@artsy/palette"
+import { useGravity } from "hooks"
+import { ArtistAutocompleteOption } from "./ArtistAutocompleteOption"
+
+type Props = Omit<
+  AutocompleteInputProps<ArtistAutocompleteInputOptionType>,
+  "options"
+>
+
+export const ArtistAutocomplete: React.FC<Props> = ({ onSelect, ...rest }) => {
+  const [query, setQuery] = useState<string>("")
+  const { data, isLoading } = useGravity<ArtistMatchHit[]>(
+    `match/artists?size=10&term=${query}`
+  )
+
+  const options: (ArtistAutocompleteInputOptionType &
+    AutocompleteInputOptionType)[] = isLoading ? [] : data.map(hitToOption)
+
+  return (
+    <AutocompleteInput
+      placeholder="Artist name"
+      options={options}
+      renderOption={(option) => <ArtistAutocompleteOption {...option} />}
+      onChange={(e) => setQuery(e.target.value)}
+      onSelect={onSelect}
+      {...rest}
+    />
+  )
+}
+
+const hitToOption = (
+  hit: ArtistMatchHit
+): ArtistAutocompleteInputOptionType => ({
+  imageUrl: hit.image_urls?.square,
+  isTargetSupply: hit.target_supply,
+  nationality: hit.nationality,
+  publishedArtworksCount: hit.published_artworks_count,
+  targetSupplyPriority: hit.target_supply_priority,
+  text: hit.name,
+  value: hit.id,
+  years: hit.years,
+})
+
+interface ArtistMatchHit {
+  id: string
+  name: string
+  image_urls: Record<string, string>
+  nationality: string
+  years: string
+  published_artworks_count: number
+  target_supply: boolean
+  target_supply_priority: number
+}
+
+export interface ArtistAutocompleteInputOptionType
+  extends AutocompleteInputOptionType {
+  imageUrl: string
+  isTargetSupply: boolean
+  nationality: string
+  publishedArtworksCount: number
+  targetSupplyPriority: number
+  years: string
+}

--- a/src/components/autocomplete/ArtistAutocompleteOption.tsx
+++ b/src/components/autocomplete/ArtistAutocompleteOption.tsx
@@ -1,0 +1,56 @@
+import Image from "next/image"
+import compact from "lodash/compact"
+import {
+  AutocompleteInputOptionLabelProps,
+  Box,
+  Flex,
+  Text,
+} from "@artsy/palette"
+
+export interface Props extends AutocompleteInputOptionLabelProps {
+  imageUrl: string
+  isTargetSupply: boolean
+  nationality: string
+  publishedArtworksCount: number
+  targetSupplyPriority: number
+  years: string
+}
+
+export const ArtistAutocompleteOption: React.FC<Props> = (props) => {
+  const {
+    imageUrl,
+    nationality,
+    publishedArtworksCount,
+    targetSupplyPriority,
+    text,
+    years,
+  } = props
+  const priority = targetSupplyPriority && `P${targetSupplyPriority}`
+  const works = publishedArtworksCount && `${publishedArtworksCount} works`
+
+  return (
+    <Flex alignItems="center" py={1}>
+      <Box ml={1} width={60} height={60} bg="black10" position="relative">
+        {imageUrl && (
+          <Image
+            src={imageUrl}
+            alt={compact([
+              "Representative artwork for",
+              text,
+              nationality,
+              years,
+            ]).join(", ")}
+            layout="fill"
+          />
+        )}
+      </Box>
+      <Box flex={1} p={1}>
+        <Text fontWeight={"bold"}>{text}</Text>
+
+        <Text textColor="black60">
+          {compact([nationality, years, priority, works]).join(", ")}
+        </Text>
+      </Box>
+    </Flex>
+  )
+}

--- a/src/components/autocomplete/UserAutocomplete.tsx
+++ b/src/components/autocomplete/UserAutocomplete.tsx
@@ -1,0 +1,54 @@
+import { useState } from "react"
+import {
+  AutocompleteInput,
+  AutocompleteInputOptionType,
+  AutocompleteInputProps,
+} from "@artsy/palette"
+import { useGravity } from "hooks"
+import { UserAutocompleteOption } from "./UserAutocompleteOption"
+
+type Props = Omit<
+  AutocompleteInputProps<UserAutocompleteInputOptionType>,
+  "options"
+>
+
+export const UserAutocomplete: React.FC<Props> = ({ onSelect, ...rest }) => {
+  const [query, setQuery] = useState<string>("")
+  const { data, isLoading } = useGravity<UserMatchHit[]>(
+    `match/users?size=10&term=${query}`
+  )
+
+  const options: (UserAutocompleteInputOptionType &
+    AutocompleteInputOptionType)[] = isLoading ? [] : data.map(hitToOption)
+
+  return (
+    <AutocompleteInput
+      placeholder="User name or email"
+      options={options}
+      renderOption={(option) => <UserAutocompleteOption {...option} />}
+      onChange={(e) => setQuery(e.target.value)}
+      onSelect={onSelect}
+      {...rest}
+    />
+  )
+}
+
+const hitToOption = (hit: UserMatchHit): UserAutocompleteInputOptionType => ({
+  email: hit.email,
+  text: hit.name,
+  value: hit.id,
+  isIdentityVerified: hit.identity_verified,
+})
+
+interface UserMatchHit {
+  id: string
+  name: string
+  email: string
+  identity_verified: boolean
+}
+
+export interface UserAutocompleteInputOptionType
+  extends AutocompleteInputOptionType {
+  email: string
+  isIdentityVerified: boolean
+}

--- a/src/components/autocomplete/UserAutocompleteOption.tsx
+++ b/src/components/autocomplete/UserAutocompleteOption.tsx
@@ -1,0 +1,45 @@
+import {
+  AutocompleteInputOptionLabelProps,
+  Box,
+  Flex,
+  Text,
+  VerifiedIcon,
+} from "@artsy/palette"
+
+export interface Props extends AutocompleteInputOptionLabelProps {
+  email: string
+  isIdentityVerified: boolean
+}
+
+export const UserAutocompleteOption: React.FC<Props> = (props) => {
+  const { email, isIdentityVerified, text } = props
+
+  return (
+    <Flex alignItems="center" p={1}>
+      <Box flex={1}>
+        <Text as="span" overflowEllipsis fontWeight={"bold"} pr={1}>
+          {text}
+        </Text>
+
+        <Text
+          as="span"
+          overflowEllipsis
+          textColor="black60"
+          position="relative"
+        >
+          {email}
+          {isIdentityVerified && (
+            <span
+              data-testid="identity-verified-badge"
+              style={{ position: "relative" }}
+            >
+              <Box position="absolute" top="0" left="0.25em">
+                <VerifiedIcon fill="green100" height={20} width={20} />
+              </Box>
+            </span>
+          )}
+        </Text>
+      </Box>
+    </Flex>
+  )
+}

--- a/src/components/autocomplete/__tests__/ArtistAutocomplete.spec.tsx
+++ b/src/components/autocomplete/__tests__/ArtistAutocomplete.spec.tsx
@@ -1,0 +1,59 @@
+import React from "react"
+import { fireEvent, render, screen } from "@testing-library/react"
+
+import { ArtistAutocomplete } from "../ArtistAutocomplete"
+
+jest.mock("hooks", () => ({
+  useGravity: (url: string) => mockGravityResponse(url),
+}))
+
+beforeEach(() => {
+  mockGravityResponse.mockClear()
+})
+
+it("renders an autocomplete input`", () => {
+  render(<ArtistAutocomplete />)
+
+  expect(screen.getByPlaceholderText("Artist name")).toBeInTheDocument()
+})
+
+it("fetches via useGravity on each keystroke", async () => {
+  render(<ArtistAutocomplete />)
+
+  const autocompleteInput = screen.getByPlaceholderText("Artist name")
+  fireEvent.change(autocompleteInput, { target: { value: "b" } })
+  expect(screen.getByText("Cardi B")).toBeInTheDocument()
+  fireEvent.change(autocompleteInput, { target: { value: "ba" } })
+  expect(screen.getByText("Omar Ba")).toBeInTheDocument()
+
+  expect(mockGravityResponse).toHaveBeenCalledTimes(3)
+})
+
+it("invokes the supplied onSelect handler when an option is chosen", async () => {
+  const handleSelect = jest.fn()
+  render(<ArtistAutocomplete onSelect={handleSelect} />)
+
+  const autocompleteInput = screen.getByPlaceholderText("Artist name")
+  fireEvent.change(autocompleteInput, { target: { value: "b" } })
+  fireEvent.mouseDown(screen.getByText("Cardi B"))
+
+  expect(handleSelect).toHaveBeenCalled()
+})
+
+/**
+ * stub requests to Gravity's artist matcher endpoint:
+ *
+ * /api/v1/match/artists?term=foo
+ */
+
+const mockGravityResponse = jest.fn((url: string) => {
+  if (url.endsWith("term=")) return { data: [] }
+
+  if (url.endsWith("term=b"))
+    return { data: [{ name: "Cardi B" }, { name: "Mel B" }] }
+
+  if (url.endsWith("term=ba"))
+    return { data: [{ name: "Omar Ba" }, { name: "Karl Ba" }] }
+
+  throw new Error(`Unexpected term: ${url}`)
+})

--- a/src/components/autocomplete/__tests__/UserAutocomplete.spec.tsx
+++ b/src/components/autocomplete/__tests__/UserAutocomplete.spec.tsx
@@ -1,0 +1,78 @@
+import React from "react"
+import { fireEvent, render, screen } from "@testing-library/react"
+
+import { UserAutocomplete } from "../UserAutocomplete"
+
+jest.mock("hooks", () => ({
+  useGravity: (url: string) => mockGravityResponse(url),
+}))
+
+beforeEach(() => {
+  mockGravityResponse.mockClear()
+})
+
+it("renders an autocomplete input`", () => {
+  render(<UserAutocomplete />)
+
+  expect(screen.getByPlaceholderText("User name or email")).toBeInTheDocument()
+})
+
+it("fetches via useGravity on each keystroke", async () => {
+  render(<UserAutocomplete />)
+
+  const autocompleteInput = screen.getByPlaceholderText("User name or email")
+  fireEvent.change(autocompleteInput, { target: { value: "b" } })
+  expect(screen.getByText("Cardi B")).toBeInTheDocument()
+  fireEvent.change(autocompleteInput, { target: { value: "ba" } })
+  expect(screen.getByText("Omar Ba")).toBeInTheDocument()
+
+  expect(mockGravityResponse).toHaveBeenCalledTimes(3)
+})
+
+it("invokes the supplied onSelect handler when an option is chosen", async () => {
+  const handleSelect = jest.fn()
+  render(<UserAutocomplete onSelect={handleSelect} />)
+
+  const autocompleteInput = screen.getByPlaceholderText("User name or email")
+  fireEvent.change(autocompleteInput, { target: { value: "b" } })
+  fireEvent.mouseDown(screen.getByText("Cardi B"))
+
+  expect(handleSelect).toHaveBeenCalled()
+})
+
+it("displays a badge for identity-verified users", async () => {
+  render(<UserAutocomplete />)
+
+  const autocompleteInput = screen.getByPlaceholderText("User name or email")
+  fireEvent.change(autocompleteInput, { target: { value: "bat" } })
+
+  screen.getByText("Batman")
+  expect(screen.getByTestId("identity-verified-badge")).toBeInTheDocument()
+})
+
+/**
+ * stub requests to Gravity's artist matcher endpoint:
+ *
+ * /api/v1/match/users?term=foo
+ */
+
+const mockGravityResponse = jest.fn((url: string) => {
+  if (url.endsWith("term=")) return { data: [] }
+
+  if (url.endsWith("term=b"))
+    return {
+      data: [{ name: "Cardi B" }, { name: "Mel B" }],
+    }
+
+  if (url.endsWith("term=ba"))
+    return {
+      data: [{ name: "Omar Ba" }, { name: "Karl Ba" }],
+    }
+
+  if (url.endsWith("term=bat"))
+    return {
+      data: [{ name: "Batman", identity_verified: true }],
+    }
+
+  throw new Error(`Unexpected term: ${url}`)
+})

--- a/src/hooks/useGravity.ts
+++ b/src/hooks/useGravity.ts
@@ -23,7 +23,13 @@ const gravityFetcher = async (path: string, accessToken: string) => {
   return json
 }
 
-export const useGravity = (url: string) => {
+export const useGravity = <T>(
+  url: string
+): {
+  data: T
+  error: unknown
+  isLoading: boolean
+} => {
   const session = useSession()
   const user = session.data?.user as UserWithAccessToken
   const { accessToken } = user

--- a/src/pages/auto/index.page.tsx
+++ b/src/pages/auto/index.page.tsx
@@ -1,0 +1,58 @@
+import { useState } from "react"
+import { Text } from "@artsy/palette"
+
+import { ArtistAutocomplete } from "components/autocomplete/ArtistAutocomplete"
+import { UserAutocomplete } from "components/autocomplete/UserAutocomplete"
+
+import type { UserAutocompleteInputOptionType } from "components/autocomplete/UserAutocomplete"
+import type { ArtistAutocompleteInputOptionType } from "components/autocomplete/ArtistAutocomplete"
+
+export default function Page() {
+  const [selectedArtist, setSelectedArtist] =
+    useState<ArtistAutocompleteInputOptionType>()
+
+  const [selectedUser, setSelectedUser] =
+    useState<UserAutocompleteInputOptionType>()
+
+  return (
+    <div>
+      <Text as="h1" variant="xxl" mb={4}>
+        Autocompletes Demo
+      </Text>
+
+      {/* Artist */}
+
+      <Text as="h2" variant="xl" my={2} pt={2}>
+        Artist
+      </Text>
+
+      <ArtistAutocomplete onSelect={setSelectedArtist} />
+
+      {selectedArtist && (
+        <pre style={{ marginTop: "1em" }}>
+          You selected this artist record
+          <br />
+          {JSON.stringify(selectedArtist, null, 2)}
+        </pre>
+      )}
+
+      {/* User */}
+
+      <Text as="h2" variant="xl" my={2} pt={2}>
+        User
+      </Text>
+
+      <UserAutocomplete onSelect={setSelectedUser} />
+
+      {selectedUser && (
+        <pre style={{ marginTop: "1em" }}>
+          You selected this user record
+          <br />
+          {JSON.stringify(selectedUser, null, 2)}
+        </pre>
+      )}
+    </div>
+  )
+}
+
+export const getServerSideProps = () => ({ props: {} }) // HACK


### PR DESCRIPTION
The goal here is to sketch out some reusable best-practice autocompletes components that will:

- have a simple interface, e.g.

  ```tsx
  <ArtistAutocomplete onSelect={artist => doSomethingWith(artist)} />
  ```

-  include all the disambiguating info needed to correctly select an item, which is especially important for artists

- set up patterns that can be repeated for other frequently accessed content types (artwork, partner, show, etc) 

This screencap below shows the Artist version. (There is also a **`UserAutocomplete`**, but I'll refrain from screencapping due to all the PII)

https://user-images.githubusercontent.com/140521/177420421-a6434b4b-af19-4590-a61b-08fed2f49a9b.mov



## REST vs Relay

This was very straightforward to implement with a fetch to Gravity's REST endpoints, but I thought it wise to at least _try_ and implement this in Relay. [Not much luck so far](https://artsy.slack.com/archives/C0376CFU527/p1657036417620809), but if we figure that out we can come back and make another pass at these. Since they are very self-contained, shouldn't matter to the call sites.

### TODO

- [x] Rough in a design
- [x] Wire it to live data
- [x] Figure out how to test
- ~Add Storybook entries~ 
  - not straightforward bc access tokens. Added a demo page at `/auto` for now
- [ ] Switch data fetching to Relay?
  - [x] paired with Damon on this, inconclusively so far
