### PR TITLE
feat(auth): require relevant roles for access to this application

### DIFF
--- a/src/components/GlobalNav.tsx
+++ b/src/components/GlobalNav.tsx
@@ -26,9 +26,16 @@ export const GlobalNav: FC<GlobalNavProps> = ({ user }) => {
             // Logged in
             <>
               <Item href="/">Home</Item>
-              <Item href="/users">Users</Item>
-              <Item href="/artists/dedupe">Dedupe Artists</Item>
-              <Item href="/uploads">Uploads</Item>
+              {(user.roles.includes("admin") ||
+                user.roles.includes("customer_support")) && (
+                <Item href="/users">Users</Item>
+              )}
+              {user.roles.includes("admin") && (
+                <Item href="/artists/dedupe">Dedupe Artists</Item>
+              )}
+              {user.roles.includes("team") && (
+                <Item href="/uploads">Uploads</Item>
+              )}
               <Anchor onClick={() => signOut()}>Logout</Anchor>
             </>
           ) : (

--- a/src/components/__stories__/GlobalNav.stories.tsx
+++ b/src/components/__stories__/GlobalNav.stories.tsx
@@ -8,6 +8,11 @@ export default {
 export const LoggedOut = () => <GlobalNav />
 export const LoggedIn = () => (
   <GlobalNav
-    user={{ id: "fake", email: "fake@artsy.net", accessToken: "fake" }}
+    user={{
+      id: "fake",
+      email: "fake@artsy.net",
+      accessToken: "fake",
+      roles: ["admin"],
+    }}
   />
 )

--- a/src/components/__tests__/GlobalNav.spec.tsx
+++ b/src/components/__tests__/GlobalNav.spec.tsx
@@ -21,6 +21,7 @@ describe("logged-in user", () => {
       id: "fake",
       email: "fake@artsymail.com",
       accessToken: "fake",
+      roles: ["admin"],
     }
 
     render(<GlobalNav user={user} />)

--- a/src/pages/api/auth/[...nextauth].page.ts
+++ b/src/pages/api/auth/[...nextauth].page.ts
@@ -1,17 +1,27 @@
 import NextAuth from "next-auth"
 import { UserinfoEndpointHandler } from "next-auth/providers"
 
+const authorizedRoles = ["admin", "customer_support", "team"] // all roles relevant to this app
+
 export default NextAuth({
   callbacks: {
-    jwt: async ({ token, account }) => {
+    // only allow those with relevant roles to sign in
+    signIn: async ({ profile }) => {
+      const userRoles = (profile.roles as string[]) || []
+      return authorizedRoles.some((r) => userRoles.includes(r))
+    },
+    jwt: async ({ token, user, account }) => {
       if (account) {
         token.access_token = account.access_token
+        token.roles = user?.roles
       }
       return token
     },
     session: async ({ session, token }) => {
       // @ts-ignore
       session.user.accessToken = token.access_token
+      // @ts-ignore
+      session.user.roles = token.roles || []
       return session
     },
   },
@@ -48,6 +58,7 @@ export default NextAuth({
           id: profile.id,
           name: profile.name,
           email: profile.email,
+          roles: profile.roles,
         }
       },
     },

--- a/src/system/index.ts
+++ b/src/system/index.ts
@@ -1,3 +1,6 @@
 import type { User } from "next-auth"
 
-export type UserWithAccessToken = User & { accessToken: string }
+export type UserWithAccessToken = User & {
+  accessToken: string
+  roles: string[]
+}


### PR DESCRIPTION
Restrict access to roles that are able to use these administrative functions in 2 ways:

* Consider users with _none_ of the applicable roles unauthorized from the whole application, showing them the built-in access denied page. Looks like:
<img width="515" alt="Screen Shot 2022-04-07 at 12 58 54 PM" src="https://user-images.githubusercontent.com/28120/162515785-716992cd-6964-426a-9a08-de568033e695.png">

* Only render navigation to functions that are accessible to each role. This doesn't truly guard anything, obviously. Similar checks should be made on the pages themselves, and the back-ends are the ultimate authority and enforcer of which functions are allowed for which roles. These explicit checks should probably be replaced by shared helpers, in this PR (if you can advise about where that should go) or later. **Forque's authorization checks are a UX convenience only.**
