### PR TITLE
feat: Admin can manage sale profile data for a user

### DIFF
--- a/src/__generated__/UserIdQuery.graphql.ts
+++ b/src/__generated__/UserIdQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<85ecf19de897d02d0db11b9efd7f89a4>>
+ * @generated SignedSource<<19711d121eb5b02169120d2dab6e5da9>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -19,6 +19,15 @@ export type UserIdQuery$data = {
     readonly email: string;
     readonly name: string;
     readonly phone: string | null;
+    readonly saleProfile: {
+      readonly internalID: string;
+      readonly addressLine1: string | null;
+      readonly addressLine2: string | null;
+      readonly city: string | null;
+      readonly state: string | null;
+      readonly zip: string | null;
+      readonly country: string | null;
+    } | null;
   } | null;
 };
 export type UserIdQuery = {
@@ -75,6 +84,55 @@ v6 = {
   "kind": "ScalarField",
   "name": "phone",
   "storageKey": null
+},
+v7 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "addressLine1",
+  "storageKey": null
+},
+v8 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "addressLine2",
+  "storageKey": null
+},
+v9 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "city",
+  "storageKey": null
+},
+v10 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "state",
+  "storageKey": null
+},
+v11 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "zip",
+  "storageKey": null
+},
+v12 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "country",
+  "storageKey": null
+},
+v13 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
 };
 return {
   "fragment": {
@@ -95,7 +153,25 @@ return {
           (v3/*: any*/),
           (v4/*: any*/),
           (v5/*: any*/),
-          (v6/*: any*/)
+          (v6/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "UserSaleProfile",
+            "kind": "LinkedField",
+            "name": "saleProfile",
+            "plural": false,
+            "selections": [
+              (v2/*: any*/),
+              (v7/*: any*/),
+              (v8/*: any*/),
+              (v9/*: any*/),
+              (v10/*: any*/),
+              (v11/*: any*/),
+              (v12/*: any*/)
+            ],
+            "storageKey": null
+          }
         ],
         "storageKey": null
       }
@@ -125,26 +201,39 @@ return {
           {
             "alias": null,
             "args": null,
-            "kind": "ScalarField",
-            "name": "id",
+            "concreteType": "UserSaleProfile",
+            "kind": "LinkedField",
+            "name": "saleProfile",
+            "plural": false,
+            "selections": [
+              (v2/*: any*/),
+              (v7/*: any*/),
+              (v8/*: any*/),
+              (v9/*: any*/),
+              (v10/*: any*/),
+              (v11/*: any*/),
+              (v12/*: any*/),
+              (v13/*: any*/)
+            ],
             "storageKey": null
-          }
+          },
+          (v13/*: any*/)
         ],
         "storageKey": null
       }
     ]
   },
   "params": {
-    "cacheID": "d66b5aae66a0bada093f595ec3607439",
+    "cacheID": "b2dced756ac481f3d28e8e4a30e42800",
     "id": null,
     "metadata": {},
     "name": "UserIdQuery",
     "operationKind": "query",
-    "text": "query UserIdQuery(\n  $userId: String!\n) {\n  user(id: $userId) {\n    internalID\n    dataTransferOptOut\n    email\n    name\n    phone\n    id\n  }\n}\n"
+    "text": "query UserIdQuery(\n  $userId: String!\n) {\n  user(id: $userId) {\n    internalID\n    dataTransferOptOut\n    email\n    name\n    phone\n    saleProfile {\n      internalID\n      addressLine1\n      addressLine2\n      city\n      state\n      zip\n      country\n      id\n    }\n    id\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "749804829e281db09acec5fb87f9d2b3";
+(node as any).hash = "6974cd618d3aaa5c3b5e47e9e0de3d30";
 
 export default node;

--- a/src/__generated__/useUpdateUserSaleProfileMutation.graphql.ts
+++ b/src/__generated__/useUpdateUserSaleProfileMutation.graphql.ts
@@ -1,0 +1,99 @@
+/**
+ * @generated SignedSource<<51f80c63c3130686ce94121a56fd996e>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest, Mutation } from 'relay-runtime';
+export type UpdateUserSaleProfileMutationInput = {
+  addressLine1?: string | null;
+  addressLine2?: string | null;
+  city?: string | null;
+  clientMutationId?: string | null;
+  country?: string | null;
+  id: string;
+  state?: string | null;
+  zip?: string | null;
+};
+export type useUpdateUserSaleProfileMutation$variables = {
+  input: UpdateUserSaleProfileMutationInput;
+};
+export type useUpdateUserSaleProfileMutation$data = {
+  readonly updateUserSaleProfile: {
+    readonly clientMutationId: string | null;
+  } | null;
+};
+export type useUpdateUserSaleProfileMutation = {
+  variables: useUpdateUserSaleProfileMutation$variables;
+  response: useUpdateUserSaleProfileMutation$data;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "input"
+  }
+],
+v1 = [
+  {
+    "alias": null,
+    "args": [
+      {
+        "kind": "Variable",
+        "name": "input",
+        "variableName": "input"
+      }
+    ],
+    "concreteType": "UpdateUserSaleProfileMutationPayload",
+    "kind": "LinkedField",
+    "name": "updateUserSaleProfile",
+    "plural": false,
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "clientMutationId",
+        "storageKey": null
+      }
+    ],
+    "storageKey": null
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "useUpdateUserSaleProfileMutation",
+    "selections": (v1/*: any*/),
+    "type": "Mutation",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "useUpdateUserSaleProfileMutation",
+    "selections": (v1/*: any*/)
+  },
+  "params": {
+    "cacheID": "82541175bdd23677fe1661393c7f486c",
+    "id": null,
+    "metadata": {},
+    "name": "useUpdateUserSaleProfileMutation",
+    "operationKind": "mutation",
+    "text": "mutation useUpdateUserSaleProfileMutation(\n  $input: UpdateUserSaleProfileMutationInput!\n) {\n  updateUserSaleProfile(input: $input) {\n    clientMutationId\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "3a1a9870ca0b1b442909bf7cc0afaa59";
+
+export default node;

--- a/src/pages/users/components/form/UserInfoForm.tsx
+++ b/src/pages/users/components/form/UserInfoForm.tsx
@@ -3,7 +3,6 @@ import {
   Column,
   GridColumns,
   Input,
-  Select,
   Text,
   TextArea,
 } from "@artsy/palette"
@@ -32,6 +31,7 @@ export const UserInfoForm: React.FC = () => {
             autoFocus
           />
         </Column>
+
         <Column span={12}>
           <Input
             name="email"
@@ -45,114 +45,6 @@ export const UserInfoForm: React.FC = () => {
         </Column>
 
         <Column span={12}>
-          <Select
-            name="namePrefix"
-            title="Name Prefix"
-            selected={values.namePrefix}
-            onChange={handleChange}
-            onBlur={handleBlur}
-            error={touched.namePrefix && errors.namePrefix}
-            mt={-0.5}
-            options={formatOptions([
-              "Mr.",
-              "Miss",
-              "Ms.",
-              "Mrs.",
-              "Dr.",
-              "Prof.",
-              "Honorable",
-            ])}
-          />
-        </Column>
-        <Column span={12}>
-          <Input
-            name="firstName"
-            title="First Name"
-            placeholder="Enter First Name"
-            value={values.firstName}
-            onChange={handleChange}
-            onBlur={handleBlur}
-            error={touched.firstName && errors.firstName}
-          />
-        </Column>
-        <Column span={12}>
-          <Input
-            name="lastName"
-            title="Last Name"
-            placeholder="Enter Last Name"
-            value={values.lastName}
-            onChange={handleChange}
-            onBlur={handleBlur}
-            error={touched.lastName && errors.lastName}
-          />
-        </Column>
-        <Column span={12}>
-          <Input
-            name="country"
-            title="Country"
-            placeholder="Enter Country"
-            value={values.country}
-            onChange={handleChange}
-            onBlur={handleBlur}
-            error={touched.country && errors.country}
-          />
-        </Column>
-        <Column span={12}>
-          <Input
-            name="postalCode"
-            title="Postal Code"
-            placeholder="Enter Postal Code"
-            value={values.postalCode}
-            onChange={handleChange}
-            onBlur={handleBlur}
-            error={touched.postalCode && errors.postalCode}
-          />
-        </Column>
-        <Column span={12}>
-          <Input
-            name="addressLine1"
-            title="Address Line 1"
-            placeholder="Enter Address Line 1"
-            value={values.addressLine1}
-            onChange={handleChange}
-            onBlur={handleBlur}
-            error={touched.addressLine1 && errors.addressLine1}
-          />
-        </Column>
-        <Column span={12}>
-          <Input
-            name="addressLine2"
-            title="Address Line 2"
-            placeholder="Enter Address Line 2"
-            value={values.addressLine2}
-            onChange={handleChange}
-            onBlur={handleBlur}
-            error={touched.addressLine2 && errors.addressLine2}
-          />
-        </Column>
-        <Column span={12}>
-          <Input
-            name="city"
-            title="City"
-            placeholder="Enter City"
-            value={values.city}
-            onChange={handleChange}
-            onBlur={handleBlur}
-            error={touched.city && errors.city}
-          />
-        </Column>
-        <Column span={12}>
-          <Input
-            name="region"
-            title="Region"
-            placeholder="Enter Region"
-            value={values.region}
-            onChange={handleChange}
-            onBlur={handleBlur}
-            error={touched.region && errors.region}
-          />
-        </Column>
-        <Column span={12}>
           <Input
             name="phoneNumber"
             title="Phone Number"
@@ -163,260 +55,7 @@ export const UserInfoForm: React.FC = () => {
             error={touched.phoneNumber && errors.phoneNumber}
           />
         </Column>
-        <Column span={12}>
-          <Select
-            name="gender"
-            title="Gender"
-            selected={values.gender}
-            onChange={handleChange}
-            onBlur={handleBlur}
-            error={touched.gender && errors.gender}
-            mt={-0.5}
-            options={formatOptions(["Male", "Female", "Nonbinary", "n/a"])}
-          />
-        </Column>
-        <Column span={12}>
-          <Select
-            name="maritalStatus"
-            title="Marital Status"
-            selected={values.maritalStatus}
-            onChange={handleChange}
-            onBlur={handleBlur}
-            error={touched.maritalStatus && errors.maritalStatus}
-            mt={-0.5}
-            options={formatOptions([
-              "Married",
-              "Single",
-              "Divorced",
-              "Widowed",
-              "Separated",
-              "Domestic Partner",
-            ])}
-          />
-        </Column>
-        <Column span={12}>
-          <Input
-            name="birthYear"
-            title="Birth Year"
-            placeholder="Enter Birth Year"
-            value={values.birthYear}
-            onChange={handleChange}
-            onBlur={handleBlur}
-            error={touched.birthYear && errors.birthYear}
-          />
-        </Column>
-        <Column span={12}>
-          <Input
-            name="spouse"
-            title="Spouse"
-            placeholder="Enter Spouse"
-            value={values.spouse}
-            onChange={handleChange}
-            onBlur={handleBlur}
-            error={touched.spouse && errors.spouse}
-          />
-        </Column>
-        <Column span={12}>
-          <Input
-            name="jobTitle"
-            title="Job Title"
-            placeholder="Enter Job Title"
-            value={values.jobTitle}
-            onChange={handleChange}
-            onBlur={handleBlur}
-            error={touched.jobTitle && errors.jobTitle}
-          />
-        </Column>
-        <Column span={12}>
-          <Input
-            name="employer"
-            title="Employer"
-            placeholder="Enter Employer"
-            value={values.employer}
-            onChange={handleChange}
-            onBlur={handleBlur}
-            error={touched.employer && errors.employer}
-          />
-        </Column>
-        <Column span={12}>
-          <Input
-            name="profession"
-            title="Profession"
-            placeholder="Enter Profession"
-            value={values.profession}
-            onChange={handleChange}
-            onBlur={handleBlur}
-            error={touched.profession && errors.profession}
-          />
-        </Column>
-        <Column span={12}>
-          <Input
-            name="salary"
-            title="Salary"
-            placeholder="Enter Salary"
-            value={values.salary}
-            onChange={handleChange}
-            onBlur={handleBlur}
-            error={touched.salary && errors.salary}
-          />
-        </Column>
-        <Column span={12}>
-          <Select
-            name="industry"
-            title="Industry"
-            selected={values.industry}
-            onChange={handleChange}
-            onBlur={handleBlur}
-            error={touched.industry && errors.industry}
-            mt={-0.5}
-            options={formatOptions([
-              "Architecture & Planning",
-              "Banking",
-              "Consulting",
-              "Education",
-              "Entertainment",
-              "Event Services",
-              "Fashion",
-              "Financial Services",
-              "Fine Art",
-              "Government",
-              "Graphic Design",
-              "Healthcare",
-              "Hospitality",
-              "Information Technology & Services",
-              "Insurance",
-              "Interior Design",
-              "Legal Services",
-              "Marketing & Advertising",
-              "Mechanical or Industrial Engineering",
-              "Media",
-              "Motion Pictures & Film",
-              "Museums & Institutions",
-              "Music",
-              "Oil & Energy",
-              "Other",
-              "Performing Arts",
-              "Political Organizations",
-              "Public Relations & Communications",
-              "Publishing",
-              "Real Estate",
-              "Retail",
-              "Student",
-              "Technology",
-              "Television",
-              "Transportation/Trucking",
-              "Utilities",
-              "Venture Capital & Private Equity",
-              "Writing & Editing",
-            ])}
-          />
-        </Column>
-        <Column span={12}>
-          <Select
-            name="buyerStatus"
-            title="Buyer Status"
-            selected={values.buyerStatus}
-            onChange={handleChange}
-            onBlur={handleBlur}
-            error={touched.buyerStatus && errors.buyerStatus}
-            mt={-0.5}
-            options={[
-              {
-                text: "Not Interested in Buying",
-                value: "10",
-              },
-              {
-                text: "Potential Buyer",
-                value: "0",
-              },
-              {
-                text: "Known Buyer",
-                value: "20",
-              },
-            ]}
-          />
-        </Column>
-        <Column span={12}>
-          <Select
-            name="priceRange"
-            title="Price Range"
-            selected={values.priceRange}
-            onChange={handleChange}
-            onBlur={handleBlur}
-            error={touched.priceRange && errors.priceRange}
-            mt={-0.5}
-            options={Object.entries({
-              "Price Unknown": 0,
-              $500: 10,
-              "< $2,500": 20,
-              "< $5,000": 30,
-              "< $10,000": 40,
-              "< $25,000": 50,
-              "< $50,000": 60,
-              "< $100,000": 70,
-              "< $250,000": 80,
-              "< $500,000": 90,
-              "$500,000+": 100,
-            }).map(([text, value]) => ({
-              text,
-              value: value.toString(),
-            }))}
-          />
-        </Column>
-        <Column span={12}>
-          <Input
-            name="workPhone"
-            title="Work Phone"
-            placeholder="Enter Work Phone"
-            value={values.workPhone}
-            onChange={handleChange}
-            onBlur={handleBlur}
-            error={touched.workPhone && errors.workPhone}
-          />
-        </Column>
-        <Column span={12}>
-          <Input
-            name="mobilePhone"
-            title="Mobile Phone"
-            placeholder="Enter Mobile Phone"
-            value={values.mobilePhone}
-            onChange={handleChange}
-            onBlur={handleBlur}
-            error={touched.mobilePhone && errors.mobilePhone}
-          />
-        </Column>
-        <Column span={12}>
-          <Input
-            name="fax"
-            title="Fax"
-            placeholder="Enter Fax"
-            value={values.fax}
-            onChange={handleChange}
-            onBlur={handleBlur}
-            error={touched.fax && errors.fax}
-          />
-        </Column>
-        <Column span={12}>
-          <Input
-            name="alternativeEmail"
-            title="Alternative Email"
-            placeholder="Enter Alternative Email"
-            value={values.alternativeEmail}
-            onChange={handleChange}
-            onBlur={handleBlur}
-            error={touched.alternativeEmail && errors.alternativeEmail}
-          />
-        </Column>
-        <Column span={12}>
-          <Checkbox
-            onSelect={(selected) => {
-              setFieldValue("auctionDenyList", selected)
-            }}
-            selected={values.auctionDenyList}
-          >
-            Auction Deny List
-          </Checkbox>
-        </Column>
+
         <Column span={12}>
           <Checkbox
             onSelect={(selected) => {
@@ -427,6 +66,7 @@ export const UserInfoForm: React.FC = () => {
             Opt-out of data transfer
           </Checkbox>
         </Column>
+
         <Column span={12}>
           <TextArea
             name="notes"
@@ -440,12 +80,4 @@ export const UserInfoForm: React.FC = () => {
       </GridColumns>
     </>
   )
-}
-
-const formatOptions = (options: string[]) => {
-  const formattedOptions = options.map((option) => ({
-    text: option,
-    value: option,
-  }))
-  return formattedOptions
 }

--- a/src/pages/users/components/form/UserSaleProfileForm.tsx
+++ b/src/pages/users/components/form/UserSaleProfileForm.tsx
@@ -67,73 +67,89 @@ export const UserSaleProfileForm: React.FC = () => {
 
         <Column span={12}>
           <Input
-            name="country"
+            name="userSaleProfile.country"
             title="Country"
             placeholder="Enter Country"
-            value={values.country}
+            value={values.userSaleProfile.country}
             onChange={handleChange}
             onBlur={handleBlur}
-            error={touched.country && errors.country}
+            error={
+              touched.userSaleProfile?.country &&
+              errors.userSaleProfile?.country
+            }
           />
         </Column>
 
         <Column span={12}>
           <Input
-            name="postalCode"
+            name="userSaleProfile.postalCode"
             title="Postal Code"
             placeholder="Enter Postal Code"
-            value={values.postalCode}
+            value={values.userSaleProfile.postalCode}
             onChange={handleChange}
             onBlur={handleBlur}
-            error={touched.postalCode && errors.postalCode}
+            error={
+              touched.userSaleProfile?.postalCode &&
+              errors.userSaleProfile?.postalCode
+            }
           />
         </Column>
 
         <Column span={12}>
           <Input
-            name="addressLine1"
+            name="userSaleProfile.addressLine1"
             title="Address Line 1"
             placeholder="Enter Address Line 1"
-            value={values.addressLine1}
+            value={values.userSaleProfile.addressLine1}
             onChange={handleChange}
             onBlur={handleBlur}
-            error={touched.addressLine1 && errors.addressLine1}
+            error={
+              touched.userSaleProfile?.addressLine1 &&
+              errors.userSaleProfile?.addressLine1
+            }
           />
         </Column>
 
         <Column span={12}>
           <Input
-            name="addressLine2"
+            name="userSaleProfile.addressLine2"
             title="Address Line 2"
             placeholder="Enter Address Line 2"
-            value={values.addressLine2}
+            value={values.userSaleProfile.addressLine2}
             onChange={handleChange}
             onBlur={handleBlur}
-            error={touched.addressLine2 && errors.addressLine2}
+            error={
+              touched.userSaleProfile?.addressLine2 &&
+              errors.userSaleProfile?.addressLine2
+            }
           />
         </Column>
 
         <Column span={12}>
           <Input
-            name="city"
+            name="userSaleProfile.city"
             title="City"
             placeholder="Enter City"
-            value={values.city}
+            value={values.userSaleProfile.city}
             onChange={handleChange}
             onBlur={handleBlur}
-            error={touched.city && errors.city}
+            error={
+              touched.userSaleProfile?.city && errors.userSaleProfile?.city
+            }
           />
         </Column>
 
         <Column span={12}>
           <Input
-            name="region"
+            name="userSaleProfile.region"
             title="Region"
             placeholder="Enter Region"
-            value={values.region}
+            value={values.userSaleProfile.region}
             onChange={handleChange}
             onBlur={handleBlur}
-            error={touched.region && errors.region}
+            error={
+              touched.userSaleProfile?.region && errors.userSaleProfile?.region
+            }
           />
         </Column>
 

--- a/src/pages/users/components/form/UserSaleProfileForm.tsx
+++ b/src/pages/users/components/form/UserSaleProfileForm.tsx
@@ -1,0 +1,431 @@
+import {
+  Checkbox,
+  Column,
+  GridColumns,
+  Input,
+  Select,
+  Text,
+  TextArea,
+} from "@artsy/palette"
+import { useUserFormContext } from "pages/users/useUserFormContext"
+
+export const UserSaleProfileForm: React.FC = () => {
+  const { handleChange, handleBlur, errors, values, touched, setFieldValue } =
+    useUserFormContext()
+
+  return (
+    <>
+      <Text variant="lg" mb={4} my={2}>
+        Sale Profile Info (Internal Only)
+      </Text>
+
+      <GridColumns>
+        <Column span={12}>
+          <Select
+            name="namePrefix"
+            title="Name Prefix"
+            selected={values.namePrefix}
+            onChange={handleChange}
+            onBlur={handleBlur}
+            error={touched.namePrefix && errors.namePrefix}
+            mt={-0.5}
+            options={formatOptions([
+              "Mr.",
+              "Miss",
+              "Ms.",
+              "Mrs.",
+              "Dr.",
+              "Prof.",
+              "Honorable",
+            ])}
+          />
+        </Column>
+
+        <Column span={12}>
+          <Input
+            name="firstName"
+            title="First Name"
+            placeholder="Enter First Name"
+            value={values.firstName}
+            onChange={handleChange}
+            onBlur={handleBlur}
+            error={touched.firstName && errors.firstName}
+          />
+        </Column>
+
+        <Column span={12}>
+          <Input
+            name="lastName"
+            title="Last Name"
+            placeholder="Enter Last Name"
+            value={values.lastName}
+            onChange={handleChange}
+            onBlur={handleBlur}
+            error={touched.lastName && errors.lastName}
+          />
+        </Column>
+
+        <Column span={12}>
+          <Input
+            name="country"
+            title="Country"
+            placeholder="Enter Country"
+            value={values.country}
+            onChange={handleChange}
+            onBlur={handleBlur}
+            error={touched.country && errors.country}
+          />
+        </Column>
+
+        <Column span={12}>
+          <Input
+            name="postalCode"
+            title="Postal Code"
+            placeholder="Enter Postal Code"
+            value={values.postalCode}
+            onChange={handleChange}
+            onBlur={handleBlur}
+            error={touched.postalCode && errors.postalCode}
+          />
+        </Column>
+
+        <Column span={12}>
+          <Input
+            name="addressLine1"
+            title="Address Line 1"
+            placeholder="Enter Address Line 1"
+            value={values.addressLine1}
+            onChange={handleChange}
+            onBlur={handleBlur}
+            error={touched.addressLine1 && errors.addressLine1}
+          />
+        </Column>
+
+        <Column span={12}>
+          <Input
+            name="addressLine2"
+            title="Address Line 2"
+            placeholder="Enter Address Line 2"
+            value={values.addressLine2}
+            onChange={handleChange}
+            onBlur={handleBlur}
+            error={touched.addressLine2 && errors.addressLine2}
+          />
+        </Column>
+
+        <Column span={12}>
+          <Input
+            name="city"
+            title="City"
+            placeholder="Enter City"
+            value={values.city}
+            onChange={handleChange}
+            onBlur={handleBlur}
+            error={touched.city && errors.city}
+          />
+        </Column>
+
+        <Column span={12}>
+          <Input
+            name="region"
+            title="Region"
+            placeholder="Enter Region"
+            value={values.region}
+            onChange={handleChange}
+            onBlur={handleBlur}
+            error={touched.region && errors.region}
+          />
+        </Column>
+
+        <Column span={12}>
+          <Select
+            name="gender"
+            title="Gender"
+            selected={values.gender}
+            onChange={handleChange}
+            onBlur={handleBlur}
+            error={touched.gender && errors.gender}
+            mt={-0.5}
+            options={formatOptions(["Male", "Female", "Nonbinary", "n/a"])}
+          />
+        </Column>
+
+        <Column span={12}>
+          <Select
+            name="maritalStatus"
+            title="Marital Status"
+            selected={values.maritalStatus}
+            onChange={handleChange}
+            onBlur={handleBlur}
+            error={touched.maritalStatus && errors.maritalStatus}
+            mt={-0.5}
+            options={formatOptions([
+              "Married",
+              "Single",
+              "Divorced",
+              "Widowed",
+              "Separated",
+              "Domestic Partner",
+            ])}
+          />
+        </Column>
+
+        <Column span={12}>
+          <Input
+            name="birthYear"
+            title="Birth Year"
+            placeholder="Enter Birth Year"
+            value={values.birthYear}
+            onChange={handleChange}
+            onBlur={handleBlur}
+            error={touched.birthYear && errors.birthYear}
+          />
+        </Column>
+
+        <Column span={12}>
+          <Input
+            name="spouse"
+            title="Spouse"
+            placeholder="Enter Spouse"
+            value={values.spouse}
+            onChange={handleChange}
+            onBlur={handleBlur}
+            error={touched.spouse && errors.spouse}
+          />
+        </Column>
+
+        <Column span={12}>
+          <Input
+            name="jobTitle"
+            title="Job Title"
+            placeholder="Enter Job Title"
+            value={values.jobTitle}
+            onChange={handleChange}
+            onBlur={handleBlur}
+            error={touched.jobTitle && errors.jobTitle}
+          />
+        </Column>
+
+        <Column span={12}>
+          <Input
+            name="employer"
+            title="Employer"
+            placeholder="Enter Employer"
+            value={values.employer}
+            onChange={handleChange}
+            onBlur={handleBlur}
+            error={touched.employer && errors.employer}
+          />
+        </Column>
+
+        <Column span={12}>
+          <Input
+            name="profession"
+            title="Profession"
+            placeholder="Enter Profession"
+            value={values.profession}
+            onChange={handleChange}
+            onBlur={handleBlur}
+            error={touched.profession && errors.profession}
+          />
+        </Column>
+
+        <Column span={12}>
+          <Input
+            name="salary"
+            title="Salary"
+            placeholder="Enter Salary"
+            value={values.salary}
+            onChange={handleChange}
+            onBlur={handleBlur}
+            error={touched.salary && errors.salary}
+          />
+        </Column>
+
+        <Column span={12}>
+          <Select
+            name="industry"
+            title="Industry"
+            selected={values.industry}
+            onChange={handleChange}
+            onBlur={handleBlur}
+            error={touched.industry && errors.industry}
+            mt={-0.5}
+            options={formatOptions([
+              "Architecture & Planning",
+              "Banking",
+              "Consulting",
+              "Education",
+              "Entertainment",
+              "Event Services",
+              "Fashion",
+              "Financial Services",
+              "Fine Art",
+              "Government",
+              "Graphic Design",
+              "Healthcare",
+              "Hospitality",
+              "Information Technology & Services",
+              "Insurance",
+              "Interior Design",
+              "Legal Services",
+              "Marketing & Advertising",
+              "Mechanical or Industrial Engineering",
+              "Media",
+              "Motion Pictures & Film",
+              "Museums & Institutions",
+              "Music",
+              "Oil & Energy",
+              "Other",
+              "Performing Arts",
+              "Political Organizations",
+              "Public Relations & Communications",
+              "Publishing",
+              "Real Estate",
+              "Retail",
+              "Student",
+              "Technology",
+              "Television",
+              "Transportation/Trucking",
+              "Utilities",
+              "Venture Capital & Private Equity",
+              "Writing & Editing",
+            ])}
+          />
+        </Column>
+
+        <Column span={12}>
+          <Select
+            name="buyerStatus"
+            title="Buyer Status"
+            selected={values.buyerStatus}
+            onChange={handleChange}
+            onBlur={handleBlur}
+            error={touched.buyerStatus && errors.buyerStatus}
+            mt={-0.5}
+            options={[
+              {
+                text: "Not Interested in Buying",
+                value: "10",
+              },
+              {
+                text: "Potential Buyer",
+                value: "0",
+              },
+              {
+                text: "Known Buyer",
+                value: "20",
+              },
+            ]}
+          />
+        </Column>
+
+        <Column span={12}>
+          <Select
+            name="priceRange"
+            title="Price Range"
+            selected={values.priceRange}
+            onChange={handleChange}
+            onBlur={handleBlur}
+            error={touched.priceRange && errors.priceRange}
+            mt={-0.5}
+            options={Object.entries({
+              "Price Unknown": 0,
+              $500: 10,
+              "< $2,500": 20,
+              "< $5,000": 30,
+              "< $10,000": 40,
+              "< $25,000": 50,
+              "< $50,000": 60,
+              "< $100,000": 70,
+              "< $250,000": 80,
+              "< $500,000": 90,
+              "$500,000+": 100,
+            }).map(([text, value]) => ({
+              text,
+              value: value.toString(),
+            }))}
+          />
+        </Column>
+
+        <Column span={12}>
+          <Input
+            name="workPhone"
+            title="Work Phone"
+            placeholder="Enter Work Phone"
+            value={values.workPhone}
+            onChange={handleChange}
+            onBlur={handleBlur}
+            error={touched.workPhone && errors.workPhone}
+          />
+        </Column>
+
+        <Column span={12}>
+          <Input
+            name="mobilePhone"
+            title="Mobile Phone"
+            placeholder="Enter Mobile Phone"
+            value={values.mobilePhone}
+            onChange={handleChange}
+            onBlur={handleBlur}
+            error={touched.mobilePhone && errors.mobilePhone}
+          />
+        </Column>
+
+        <Column span={12}>
+          <Input
+            name="fax"
+            title="Fax"
+            placeholder="Enter Fax"
+            value={values.fax}
+            onChange={handleChange}
+            onBlur={handleBlur}
+            error={touched.fax && errors.fax}
+          />
+        </Column>
+
+        <Column span={12}>
+          <Input
+            name="alternativeEmail"
+            title="Alternative Email"
+            placeholder="Enter Alternative Email"
+            value={values.alternativeEmail}
+            onChange={handleChange}
+            onBlur={handleBlur}
+            error={touched.alternativeEmail && errors.alternativeEmail}
+          />
+        </Column>
+
+        <Column span={12}>
+          <Checkbox
+            onSelect={(selected) => {
+              setFieldValue("auctionDenyList", selected)
+            }}
+            selected={values.auctionDenyList}
+          >
+            Auction Deny List
+          </Checkbox>
+        </Column>
+
+        <Column span={12}>
+          <TextArea
+            name="notes"
+            placeholder="Enter Notes"
+            value={values.notes}
+            onChange={handleChange}
+            onBlur={handleBlur}
+            error={touched.notes && errors.notes}
+          />
+        </Column>
+      </GridColumns>
+    </>
+  )
+}
+
+const formatOptions = (options: string[]) => {
+  const formattedOptions = options.map((option) => ({
+    text: option,
+    value: option,
+  }))
+  return formattedOptions
+}

--- a/src/pages/users/components/form/index.tsx
+++ b/src/pages/users/components/form/index.tsx
@@ -3,6 +3,7 @@ import { CollectorProfileForm } from "./CollectorProfileForm"
 import { UserAdminForm } from "./UserAdminForm"
 import { UserFairActionsForm } from "./UserFairActionsForm"
 import { UserInfoForm } from "./UserInfoForm"
+import { UserSaleProfileForm } from "./UserSaleProfileForm"
 import { UserInterestsForm } from "./UserInterestsForm"
 import { UserTagsForm } from "./UserTagsForm"
 
@@ -12,6 +13,7 @@ export const UserForm: React.FC = () => {
       <GridColumns>
         <Column span={4}>
           <UserInfoForm />
+          <UserSaleProfileForm />
         </Column>
         <Column span={4} px={4}>
           <CollectorProfileForm />

--- a/src/pages/users/mutations/useUpdateUserSaleProfile.ts
+++ b/src/pages/users/mutations/useUpdateUserSaleProfile.ts
@@ -1,0 +1,17 @@
+import { useMutation } from "hooks/useMutation"
+import { graphql } from "react-relay"
+import { useUpdateUserSaleProfileMutation } from "__generated__/useUpdateUserSaleProfileMutation.graphql"
+
+export const useUpdateUserSaleProfile = () => {
+  return useMutation<useUpdateUserSaleProfileMutation>({
+    mutation: graphql`
+      mutation useUpdateUserSaleProfileMutation(
+        $input: UpdateUserSaleProfileMutationInput!
+      ) {
+        updateUserSaleProfile(input: $input) {
+          clientMutationId
+        }
+      }
+    `,
+  })
+}

--- a/src/pages/users/useUserFormContext.tsx
+++ b/src/pages/users/useUserFormContext.tsx
@@ -16,13 +16,15 @@ export interface UserFormValues {
   namePrefix?: string
   firstName?: string
   lastName?: string
-  postalCode?: string
-  addressLine1?: string
-  addressLine2?: string
-  city?: string
-  region?: string
+  userSaleProfile: {
+    addressLine1?: string
+    addressLine2?: string
+    city?: string
+    region?: string
+    postalCode?: string
+    country?: string
+  }
   phoneNumber?: string
-  country?: string
   gender?: string
   maritalStatus?: string
   birthYear?: string


### PR DESCRIPTION
This PR lands the management of a nested user model - the `SaleProfile`. This is a layer on top of our user data where we can override certain details if we want. In order to support this editing I added a query/mutation pair here:

https://github.com/artsy/metaphysics/pull/3952

The query is under `user` and the mutation is root-level. So yeah these fields are wired up!

<img width="1310" alt="Screen Shot 2022-04-13 at 4 09 03 PM" src="https://user-images.githubusercontent.com/79799/163270934-9db94fc7-7319-4b12-830c-7bba56392fef.png">

