### PR TITLE
chore: remove old internal ingress declarations #migration (PLATFORM-4093)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@ A home for admin apps
 ## Meta
 
 - **State:** development
-- **Staging:** [https://forque.stg.artsy.systems](https://forque.stg.artsy.systems)
+- **Staging:** [https://tools-staging.artsy.net](https://tools-staging.artsy.net)
   - [Kubernetes](https://kubernetes.stg.artsy.systems/#/search?q=forque&namespace=default)
-- **Production:** [https://forque.prd.artsy.systems](https://forque.prd.artsy.systems)
+- **Production:** [https://tools.artsy.net](https://tools.artsy.net)
   - [Kubernetes](https://kubernetes.prd.artsy.systems/#/search?q=forque&namespace=default)
 - **GitHub:** [https://github.com/artsy/forque](https://github.com/artsy/forque)
 - **Deployment:**

--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -125,23 +125,6 @@ spec:
 apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
-  name: {{ project_name }}
-spec:
-  ingressClassName: nginx-internal
-  rules:
-    - host: {{ project_name }}.prd.artsy.systems
-      http:
-        paths:
-          - path: /
-            pathType: Prefix
-            backend:
-              serviceName: {{ project_name }}-web-internal
-              servicePort: http
-
----
-apiVersion: networking.k8s.io/v1beta1
-kind: Ingress
-metadata:
   name: {{ project_name }}-public
 spec:
   ingressClassName: nginx

--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -125,23 +125,6 @@ spec:
 apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
-  name: {{ project_name }}
-spec:
-  ingressClassName: nginx-internal
-  rules:
-    - host: {{ project_name }}.stg.artsy.systems
-      http:
-        paths:
-          - path: /
-            pathType: Prefix
-            backend:
-              serviceName: {{ project_name }}-web-internal
-              servicePort: http
-
----
-apiVersion: networking.k8s.io/v1beta1
-kind: Ingress
-metadata:
   name: {{ project_name }}-public
 spec:
   ingressClassName: nginx


### PR DESCRIPTION
This follows up https://github.com/artsy/forque/pull/76 by removing the internal ingress resources that are no longer used.

**Post-deploy, these resources will need to be manually deleted from staging and production clusters because that won't happen automatically.**