### PR TITLE
Streamline authorization

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -7,6 +7,7 @@ const createJestConfig = nextJest({
 
 // Add any custom config to be passed to Jest
 const customJestConfig = {
+  moduleDirectories: ["node_modules", "src"],
   roots: ["<rootDir>/src"],
   setupFilesAfterEnv: ["<rootDir>/jest.setup.js"],
   testEnvironment: "jest-environment-jsdom",

--- a/src/components/GlobalNav.tsx
+++ b/src/components/GlobalNav.tsx
@@ -5,6 +5,7 @@ import Link from "next/link"
 import { useRouter } from "next/router"
 import { FC } from "react"
 import styled, { css } from "styled-components"
+import { isPermitted, Action } from "system"
 import type { UserWithAccessToken } from "system"
 
 interface GlobalNavProps {
@@ -31,16 +32,16 @@ export const GlobalNav: FC<GlobalNavProps> = ({ user }) => {
           // Logged in
           <>
             <Item href="/">Home</Item>
-            {user.roles.includes("customer_support") && (
+            {isPermitted(user, [Action.list], "users") && (
               <Item href="/users">Users</Item>
             )}
-            {user.roles.includes("metadata_admin") && (
+            {isPermitted(user, [Action.dedupe], "artists") && (
               <Item href="/artists/dedupe">Dedupe Artists</Item>
             )}
-            {user.roles.includes("customer_support") && (
+            {isPermitted(user, [Action.transfer], "my_collection") && (
               <Item href="/my-collection">My Collection</Item>
             )}
-            {user.roles.includes("team") && (
+            {isPermitted(user, [Action.list, Action.create], "uploads") && (
               <Item href="/uploads">Uploads</Item>
             )}
             <Item href="#" onClick={() => signOut()}>

--- a/src/components/GlobalNav.tsx
+++ b/src/components/GlobalNav.tsx
@@ -31,15 +31,13 @@ export const GlobalNav: FC<GlobalNavProps> = ({ user }) => {
           // Logged in
           <>
             <Item href="/">Home</Item>
-            {(user.roles.includes("admin") ||
-              user.roles.includes("customer_support")) && (
+            {user.roles.includes("customer_support") && (
               <Item href="/users">Users</Item>
             )}
-            {user.roles.includes("admin") && (
+            {user.roles.includes("metadata_admin") && (
               <Item href="/artists/dedupe">Dedupe Artists</Item>
             )}
-            {(user.roles.includes("admin") ||
-              user.roles.includes("customer_support")) && (
+            {user.roles.includes("customer_support") && (
               <Item href="/my-collection">My Collection</Item>
             )}
             {user.roles.includes("team") && (

--- a/src/components/__stories__/GlobalNav.stories.tsx
+++ b/src/components/__stories__/GlobalNav.stories.tsx
@@ -12,7 +12,7 @@ export const LoggedIn = () => (
       id: "fake",
       email: "fake@artsy.net",
       accessToken: "fake",
-      roles: ["admin"],
+      roles: ["team", "metadata_admin"],
     }}
   />
 )

--- a/src/components/__tests__/GlobalNav.spec.tsx
+++ b/src/components/__tests__/GlobalNav.spec.tsx
@@ -21,7 +21,7 @@ describe("logged-in user", () => {
       id: "fake",
       email: "fake@artsymail.com",
       accessToken: "fake",
-      roles: ["admin"],
+      roles: ["team"],
     }
 
     render(<GlobalNav user={user} />)

--- a/src/pages/api/auth/[...nextauth].page.ts
+++ b/src/pages/api/auth/[...nextauth].page.ts
@@ -1,7 +1,7 @@
 import NextAuth from "next-auth"
 import { UserinfoEndpointHandler } from "next-auth/providers"
 
-const authorizedRoles = ["admin", "customer_support", "team"] // all roles relevant to this app
+const authorizedRoles = ["customer_support", "metadata_admin", "team"] // all roles relevant to this app
 
 export default NextAuth({
   callbacks: {

--- a/src/pages/api/auth/[...nextauth].page.ts
+++ b/src/pages/api/auth/[...nextauth].page.ts
@@ -1,14 +1,13 @@
 import NextAuth from "next-auth"
 import { UserinfoEndpointHandler } from "next-auth/providers"
-
-const authorizedRoles = ["customer_support", "metadata_admin", "team"] // all roles relevant to this app
+import { Role } from "system"
 
 export default NextAuth({
   callbacks: {
     // only allow those with relevant roles to sign in
     signIn: async ({ profile }) => {
       const userRoles = (profile.roles as string[]) || []
-      return authorizedRoles.some((r) => userRoles.includes(r))
+      return Object.values(Role).some((r) => userRoles.includes(r))
     },
     jwt: async ({ token, user, account }) => {
       if (account) {

--- a/src/system/__tests__/index.spec.ts
+++ b/src/system/__tests__/index.spec.ts
@@ -1,0 +1,44 @@
+import { isPermitted, Action, UserWithAccessToken } from "system"
+
+const basicUser: UserWithAccessToken = {
+  id: "fake",
+  email: "fake@artsy.net",
+  accessToken: "fake",
+  roles: [],
+}
+
+describe("isPermitted", () => {
+  it("rejects unauthorized user", () => {
+    const user: UserWithAccessToken = {
+      ...basicUser,
+      roles: ["genomer"],
+    }
+    expect(isPermitted(user, [Action.list], "artists")).toEqual(false)
+  })
+
+  it("permits authorized user", () => {
+    const user: UserWithAccessToken = {
+      ...basicUser,
+      roles: ["metadata_admin"],
+    }
+    expect(isPermitted(user, [Action.list], "artists")).toEqual(true)
+  })
+
+  it("permits user who is authorized for any of the specified actions", () => {
+    const user: UserWithAccessToken = {
+      ...basicUser,
+      roles: ["metadata_admin"],
+    }
+    expect(isPermitted(user, [Action.list, Action.create], "artists")).toEqual(
+      true
+    )
+  })
+
+  it("rejects unrecognized action", () => {
+    const user: UserWithAccessToken = {
+      ...basicUser,
+      roles: ["metadata_admin"],
+    }
+    expect(isPermitted(user, [Action.transfer], "artists")).toEqual(false)
+  })
+})

--- a/src/system/index.ts
+++ b/src/system/index.ts
@@ -4,3 +4,50 @@ export type UserWithAccessToken = User & {
   accessToken: string
   roles: string[]
 }
+
+// all supported roles
+export enum Role {
+  customer_support = "customer_support",
+  metadata_admin = "metadata_admin",
+  team = "team",
+}
+
+export enum Action {
+  list,
+  dedupe,
+  create,
+  transfer,
+}
+
+// For each _domain_, a map of _actions_ to the authorized _roles_.
+const PERMISSIONS: Record<string, Record<string, Role[]>> = {
+  users: {
+    [Action.list]: [Role.customer_support],
+  },
+  artists: {
+    [Action.dedupe]: [Role.metadata_admin],
+    [Action.list]: [Role.metadata_admin],
+  },
+  my_collection: {
+    [Action.transfer]: [Role.customer_support],
+  },
+  uploads: {
+    [Action.list]: [Role.team],
+    [Action.create]: [Role.team],
+  },
+}
+
+type Domain = keyof typeof PERMISSIONS
+
+export const isPermitted = (
+  user: UserWithAccessToken,
+  actions: Action[],
+  domain: Domain
+) => {
+  return actions.some((action) => {
+    const permittedRoles = PERMISSIONS[domain][action] || []
+    return permittedRoles.some((permittedRole) =>
+      user.roles.includes(`${permittedRole}`)
+    )
+  })
+}


### PR DESCRIPTION
This PR does 2 [related] things, so it might be easiest to review the commits separately.

1. Avoid relying on the legacy, overly-broad `admin` role for access to any tools. This is just a small step, and APIs will ultimately need to narrow their access as well. At least this limits the new functionality granted to `admin`s and decreases the need for that role.

2. Add an `isPermitted` helper so that authorization rules can be declared clearly in just one location, then referenced everywhere. Tell me what you think of the interface!

It bears repeating that these authorization rules are only a UX convenience, and ultimately enforcement must be at the API(s).