### PR TITLE
fix: correct name of datadog trace agent variable

### DIFF
--- a/datadog.js
+++ b/datadog.js
@@ -1,6 +1,6 @@
 if (process.env.DD_APM_ENABLED) {
   const tracer = require('dd-trace').init({
-    hostname: process.env.DD_TRACE_AGENT_HOSTNAME,
+    hostname: process.env.DATADOG_TRACE_AGENT_HOSTNAME,
     service: "forque",
   })
 


### PR DESCRIPTION
This PR corrects #101 to use the correct env key for the datadog agent, set in the config [here](https://github.com/artsy/forque/blob/main/hokusai/staging.yml#L38). 