### PR TITLE
fix: revert yarn/node orb version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ orbs:
   cypress: cypress-io/cypress@1
   hokusai: artsy/hokusai@volatile
   horizon: artsy/release@volatile
-  yarn: artsy/yarn@volatile
+  yarn: artsy/yarn@6.1.0
 
 not_staging_or_release: &not_staging_or_release
   filters:


### PR DESCRIPTION
bumped these orbs version to latest in https://github.com/artsy/forque/pull/100, not realizing they carry node version. undo.