### PR TITLE
fix: disable SentryWebpackPlugin

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -18,6 +18,10 @@ const nextConfig = {
     NEXT_PUBLIC_METAPHYSICS_URL: process.env.NEXT_PUBLIC_METAPHYSICS_URL,
   },
   reactStrictMode: true,
+  sentry: {
+    disableServerWebpackPlugin: true,
+    disableClientWebpackPlugin: true,
+  }
 }
 
 const sentryWebpackPluginOptions = {
@@ -34,4 +38,4 @@ const sentryWebpackPluginOptions = {
 
 // Make sure adding Sentry options is the last code to run before exporting, to
 // ensure that your source maps include changes from all other Webpack plugins
-module.exports = withSentryConfig(nextConfig, sentryWebpackPluginOptions);
+module.exports = withSentryConfig(nextConfig);


### PR DESCRIPTION
This PR [disables](https://docs.sentry.io/platforms/javascript/guides/nextjs/manual-setup/#disable-sentrywebpackplugin) the sentryWebpackPlugin which requires `setnry-cli`. Due to sentry authentication errors, this is [blocking staging deploys](https://app.circleci.com/pipelines/github/artsy/forque?branch=main&filter=all), so disabling this is a temp fix while we decide to resolve this or move forward with it disabled. 