### PR TITLE
fix: homepage styling

### DIFF
--- a/src/pages/index.page.tsx
+++ b/src/pages/index.page.tsx
@@ -1,3 +1,4 @@
+import { Box, Flex, Text } from "@artsy/palette"
 import { GetServerSideProps } from "next"
 import Head from "next/head"
 import Image from "next/image"
@@ -18,21 +19,19 @@ export default function Home({ me }: HomeProps) {
         <link rel="icon" href="/favicon.ico" />
       </Head>
 
-      <div className="flex flex-col items-center mt-4 sm:mt-12">
-        <h1 className="mb-4 text-xxl">Welcome to Artsy</h1>
-        <p className="mb-4">
-          Hi, <strong>{me?.email}</strong>
-        </p>
-        <div className="relative [width:20em] aspect-[196/129]">
+      <Flex flexDirection="column" alignItems="center" mt={[4, 12]}>
+        <Text variant="xxl">Welcome to Artsy</Text>
+
+        <Text my={4}>Hi, {me?.email}</Text>
+
+        <Box position="relative" width="20em" height="13em">
           <Image
             src="/under.gif"
-            width={196}
-            height={129}
             layout="fill"
             alt="Pikachu jackhammering in front of an Under Construction sign"
           />
-        </div>
-      </div>
+        </Box>
+      </Flex>
     </div>
   )
 }


### PR DESCRIPTION
Fell into a deep rabbithole of debugging the artist merging logic in Gravity, so I'm instead grabbing a quick, silly win…

I don't mean to actually double-down on Pikachu but it does bug me that he doesn't show up in Safari…

## Before

Safari on the right-hand side...

<img width="3008" alt="pbefore" src="https://user-images.githubusercontent.com/140521/166077879-327dd0a6-5b8f-461f-916b-1cccb66038df.png">

## After

The Next `Image` element needed a container with an explicit height. Not sure why Chrome and Safari didn't agree, but was easy just to set it explicitly, and Palette-ify while I was at it.

<img width="3008" alt="pafter" src="https://user-images.githubusercontent.com/140521/166077880-06cb1b14-cd1f-4247-82ed-f56726b0dff0.png">
