### PR TITLE
fix: enable sentry webpack

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -28,6 +28,7 @@ const sentryWebpackPluginOptions = {
   //   release, url, org, project, authToken, configFile, stripPrefix,
   //   urlPrefix, include, ignore
 
+  // necesary to use authenticat sentry-cli
   authToken: process.env.SENTRY_AUTH_TOKEN,
 
   silent: true, // Suppresses all logs

--- a/next.config.js
+++ b/next.config.js
@@ -18,11 +18,7 @@ const nextConfig = {
     NEXT_PUBLIC_GRAVITY_URL: process.env.NEXT_PUBLIC_GRAVITY_URL,
     NEXT_PUBLIC_METAPHYSICS_URL: process.env.NEXT_PUBLIC_METAPHYSICS_URL,
   },
-  reactStrictMode: true,
-  sentry: {
-    disableServerWebpackPlugin: true,
-    disableClientWebpackPlugin: true,
-  }
+  reactStrictMode: true
 }
 
 const sentryWebpackPluginOptions = {
@@ -32,6 +28,8 @@ const sentryWebpackPluginOptions = {
   //   release, url, org, project, authToken, configFile, stripPrefix,
   //   urlPrefix, include, ignore
 
+  authToken: process.env.SENTRY_AUTH_TOKEN,
+
   silent: true, // Suppresses all logs
   // For all available options, see:
   // https://github.com/getsentry/sentry-webpack-plugin#options.
@@ -39,4 +37,4 @@ const sentryWebpackPluginOptions = {
 
 // Make sure adding Sentry options is the last code to run before exporting, to
 // ensure that your source maps include changes from all other Webpack plugins
-module.exports = withSentryConfig(nextConfig);
+module.exports = withSentryConfig(nextConfig, sentryWebpackPluginOptions);

--- a/next.config.js
+++ b/next.config.js
@@ -28,7 +28,7 @@ const sentryWebpackPluginOptions = {
   //   release, url, org, project, authToken, configFile, stripPrefix,
   //   urlPrefix, include, ignore
 
-  // necesary to use authenticat sentry-cli
+  // necessary to use authenticat sentry-cli
   authToken: process.env.SENTRY_AUTH_TOKEN,
 
   silent: true, // Suppresses all logs


### PR DESCRIPTION
This reenabled sentry's webpack plugin after disabling it in #119 due to failing builds. After having created a new integration for each project (required to get an auth token - see [docs](https://docs.sentry.io/product/integrations/integration-platform/#auth-tokens-1)), we can pass the key in directly into the `sentryWebpackPluginOptions`.  