### PR TITLE
fix: disable sentry webpack config part two

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -18,24 +18,13 @@ const nextConfig = {
     NEXT_PUBLIC_GRAVITY_URL: process.env.NEXT_PUBLIC_GRAVITY_URL,
     NEXT_PUBLIC_METAPHYSICS_URL: process.env.NEXT_PUBLIC_METAPHYSICS_URL,
   },
-  reactStrictMode: true
+  reactStrictMode: true,
+  sentry: {
+    disableServerWebpackPlugin: true,
+    disableClientWebpackPlugin: true,
+  }
 }
-
-const sentryWebpackPluginOptions = {
-  // Additional config options for the Sentry Webpack plugin. Keep in mind that
-  // the following options are set automatically, and overriding them is not
-  // recommended:
-  //   release, url, org, project, authToken, configFile, stripPrefix,
-  //   urlPrefix, include, ignore
-
-  // necessary to use authenticat sentry-cli
-  authToken: process.env.SENTRY_AUTH_TOKEN,
-
-  silent: true, // Suppresses all logs
-  // For all available options, see:
-  // https://github.com/getsentry/sentry-webpack-plugin#options.
-};
 
 // Make sure adding Sentry options is the last code to run before exporting, to
 // ensure that your source maps include changes from all other Webpack plugins
-module.exports = withSentryConfig(nextConfig, sentryWebpackPluginOptions);
+module.exports = withSentryConfig(nextConfig);

--- a/sentry.properties
+++ b/sentry.properties
@@ -1,4 +1,0 @@
-defaults.url=https://sentry.io/
-defaults.org=artsynet
-defaults.project=forque
-cli.executable=../../.npm/_npx/43087/lib/node_modules/@sentry/wizard/node_modules/@sentry/cli/bin/sentry-cli


### PR DESCRIPTION
Disables the webpack sentry config. We have agreed to punt this work as it isn't time-sensitive and the actual value provided is unclear. Slack thread [here](https://artsy.slack.com/archives/CA8SANW3W/p1651688362705429)

Could be a good FF project.

### Related PR(s)
- #119 

[PLATFORM-4144]

[PLATFORM-4144]: https://artsyproduct.atlassian.net/browse/PLATFORM-4144?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ