### PR TITLE
fix(uploader): swr call uses array as key to impose no cache

### DIFF
--- a/src/pages/uploads/components/Uploader.tsx
+++ b/src/pages/uploads/components/Uploader.tsx
@@ -19,11 +19,20 @@ export const Uploader: FC<UploaderProps> = ({ file }) => {
 
   const router = useRouter()
 
+  // HACK: Impose no cache for Uploader SWR call to address behavior where an
+  //   existing file is overwritten when performing consecutive uploads using a
+  //   new file with same name during the same browser session.
+  //   Adopted from: https://github.com/vercel/swr/discussions/456#discussioncomment-25602
+  const random = useRef(Date.now())
+
   const { data } = useSWR<PresignedPost>(
-    {
-      url: `/api/uploads/presignedPosts/${encodeURIComponent(key)}`,
-      args: { contentType: file.type },
-    },
+    [
+      {
+        url: `/api/uploads/presignedPosts/${encodeURIComponent(key)}`,
+        args: { contentType: file.type },
+      },
+      random.current,
+    ],
     fetcher
   )
 


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/PLATFORM-4137

This PR attempts to solve an issue with the `Uploader` when performing consecutive uploads during the same session and overwriting an already uploaded file with the same name. It was surfaced by @anandaroop [here](https://artsy.slack.com/archives/C0376CFU527/p1651264636623859?thread_ts=1649338641.149999&cid=C0376CFU527) and is further discussed in that thread.

The issue is two fold:
1. Currently the uploader will overwrite the image in s3 if another image is uploaded with the same filename (_during the same browser session_)
2. Stale data is getting used when performing consecutive uploads using the same filename

Issue further explained in this [this slack comment](https://artsy.slack.com/archives/C0376CFU527/p1651677507873279?thread_ts=1649338641.149999&cid=C0376CFU527).

The PR modifies the Uploader [_SWR_](https://swr.vercel.app/docs/options#parameters) parameter `key` to be an array and pass an additional element which imposes a _no cache_ behavior when fetching data. This approach was adopted from this [github discussion](https://github.com/vercel/swr/discussions/456#discussioncomment-25602).

https://user-images.githubusercontent.com/29984068/167151196-fafdb43a-41e1-4e28-a380-e720100430c4.mp4

[It appears](https://artsy.slack.com/archives/C0376CFU527/p1651846489117919?thread_ts=1649338641.149999&cid=C0376CFU527) the uploading behavior is different (the issue is worse) in deployed staging environment vs when running locally.
