### PR TITLE
Revert "fix(uploader): swr call uses array as key to impose no cache"

### DIFF
--- a/src/pages/uploads/components/Uploader.tsx
+++ b/src/pages/uploads/components/Uploader.tsx
@@ -19,20 +19,11 @@ export const Uploader: FC<UploaderProps> = ({ file }) => {
 
   const router = useRouter()
 
-  // HACK: Impose no cache for Uploader SWR call to address behavior where an
-  //   existing file is overwritten when performing consecutive uploads using a
-  //   new file with same name during the same browser session.
-  //   Adopted from: https://github.com/vercel/swr/discussions/456#discussioncomment-25602
-  const random = useRef(Date.now())
-
   const { data } = useSWR<PresignedPost>(
-    [
-      {
-        url: `/api/uploads/presignedPosts/${encodeURIComponent(key)}`,
-        args: { contentType: file.type },
-      },
-      random.current,
-    ],
+    {
+      url: `/api/uploads/presignedPosts/${encodeURIComponent(key)}`,
+      args: { contentType: file.type },
+    },
     fetcher
   )
 


### PR DESCRIPTION
Revert artsy/forque#133