### PR TITLE
feat(nav): remove incomplete features from nav for now

### DIFF
--- a/src/components/GlobalNav.tsx
+++ b/src/components/GlobalNav.tsx
@@ -32,12 +32,12 @@ export const GlobalNav: FC<GlobalNavProps> = ({ user }) => {
           // Logged in
           <>
             <Item href="/">Home</Item>
-            {isPermitted(user, [Action.list], "users") && (
+            {/* {isPermitted(user, [Action.list], "users") && (
               <Item href="/users">Users</Item>
             )}
             {isPermitted(user, [Action.dedupe], "artists") && (
               <Item href="/artists/dedupe">Dedupe Artists</Item>
-            )}
+            )} */}
             {isPermitted(user, [Action.transfer], "my_collection") && (
               <Item href="/my-collection">My Collection</Item>
             )}
@@ -54,7 +54,6 @@ export const GlobalNav: FC<GlobalNavProps> = ({ user }) => {
         ) : (
           // Logged out
           <>
-            <Item href="/">Home</Item>
             <Item href="#" onClick={() => signIn("artsy")}>
               Login
             </Item>


### PR DESCRIPTION
As [suggested](https://artsy.slack.com/archives/CA8SANW3W/p1651248514539759?thread_ts=1651246935.816309), let's avoid linking to incomplete features in the nav. This allows us to start directing real users to the first few tools without risk of confusion.