### PR TITLE
feat(auth): raise friendly, meaningful errors when a function is forbidden

### DIFF
--- a/src/pages/artists/dedupe/index.page.tsx
+++ b/src/pages/artists/dedupe/index.page.tsx
@@ -1,6 +1,8 @@
 import { useState } from "react"
 import { useMetaphysics } from "hooks"
 import { ArtistList, Skeleton } from "./components/list/ArtistList"
+import { useSession } from "next-auth/react"
+import { Action, assertPermitted, UserWithAccessToken } from "system"
 
 const PER_PAGE = 36
 
@@ -14,6 +16,10 @@ export type RecentArtist = {
 }
 
 export default function Page() {
+  const session = useSession()
+  const user = session.data?.user as UserWithAccessToken
+  assertPermitted(user, Action.list, "artists")
+
   const [page, setPage] = useState<number>(1)
 
   const { data, error, isLoading } = useMetaphysics(

--- a/src/pages/my-collection/index.page.tsx
+++ b/src/pages/my-collection/index.page.tsx
@@ -1,9 +1,15 @@
 import { Text } from "@artsy/palette"
+import { useSession } from "next-auth/react"
 import Head from "next/head"
 import { FC } from "react"
+import { Action, assertPermitted, UserWithAccessToken } from "system"
 import { MyCollectionTransfer } from "./components/MyCollectionTransfer"
 
 const MyCollectionPage: FC = () => {
+  const session = useSession()
+  const user = session.data?.user as UserWithAccessToken
+  assertPermitted(user, Action.transfer, "my_collection")
+
   return (
     <>
       <Head>

--- a/src/pages/shortcuts/index.page.tsx
+++ b/src/pages/shortcuts/index.page.tsx
@@ -2,8 +2,15 @@ import { Tabs, Tab } from "@artsy/palette"
 import { FC } from "react"
 import { CreateOrEditShortcutForm } from "./components/CreateOrEditShortcutForm"
 import { EditShortcut } from "./components/EditShortcut"
+import { assertPermitted, Action } from "system"
+import type { UserWithAccessToken } from "system"
+import { useSession } from "next-auth/react"
 
 const ShortcutsPage: FC = () => {
+  const session = useSession()
+  const user = session.data?.user as UserWithAccessToken
+  assertPermitted(user, Action.create, "shortcuts")
+
   return (
     <>
       <Tabs>

--- a/src/pages/uploads/index.page.tsx
+++ b/src/pages/uploads/index.page.tsx
@@ -1,12 +1,18 @@
 import { AutocompleteInput, Column, GridColumns, Text } from "@artsy/palette"
 import { ListObjectsV2Output } from "aws-sdk/clients/s3"
+import { useSession } from "next-auth/react"
 import Head from "next/head"
 import { useRouter } from "next/router"
 import { FC, useState } from "react"
 import useSWR from "swr"
+import { Action, assertPermitted, UserWithAccessToken } from "system"
 import { UploadButton } from "./components/UploadButton"
 
 const UploadsPage: FC = () => {
+  const session = useSession()
+  const user = session.data?.user as UserWithAccessToken
+  assertPermitted(user, Action.create, "uploads")
+
   const router = useRouter()
 
   const [prefix, setPrefix] = useState("")

--- a/src/pages/users/index.page.tsx
+++ b/src/pages/users/index.page.tsx
@@ -4,12 +4,18 @@ import { graphql } from "relay-runtime"
 import { usersQuery } from "__generated__/usersQuery.graphql"
 import Head from "next/head"
 import { UsersTable } from "./components/UsersTable"
+import { useSession } from "next-auth/react"
+import { Action, assertPermitted, UserWithAccessToken } from "system"
 
 interface UserProps {
   viewer: usersQuery["response"]["viewer"]
 }
 
 const Users: React.FC<UserProps> = ({ viewer }) => {
+  const session = useSession()
+  const user = session.data?.user as UserWithAccessToken
+  assertPermitted(user, Action.list, "users")
+
   return (
     <>
       <Head>

--- a/src/system/ErrorBoundary.tsx
+++ b/src/system/ErrorBoundary.tsx
@@ -1,46 +1,52 @@
-import React from "react"
+import React, { ReactNode } from "react"
+import { Text } from "@artsy/palette"
 
-interface ErrorBoundaryState {
-  hasError: boolean
-  error: any
+interface Props {
+  children: ReactNode
 }
 
-export class ErrorBoundary extends React.Component<
-  React.ComponentPropsWithRef<any>,
-  ErrorBoundaryState
-> {
+interface State {
+  hasError: boolean
+  errorMessage: string
+}
+
+export class ErrorBoundary extends React.Component<Props, State> {
   constructor(props: any) {
     super(props)
 
     this.state = {
       hasError: false,
-      error: null,
+      errorMessage: "Something went wrong",
     }
   }
 
-  static getDerivedStateFromError(error: any) {
+  static getDerivedStateFromError(error: Error): Partial<State> {
     return {
       hasError: true,
-      error,
+      errorMessage: error.message,
     }
   }
 
   componentDidCatch(error: any, errorInfo: any) {
+    // TODO: send this to Sentry in addition / instead?
     console.error("[forque] Error:", error, errorInfo)
   }
 
   render() {
-    const { hasError, error, children } = this.props
-
-    if (hasError) {
+    if (this.state.hasError) {
       return (
         <div>
-          <h1>Something went wrong.</h1>
-          <pre>{error}</pre>
+          <Text as="h1" variant="xxl">
+            Error
+          </Text>
+
+          <Text variant="lg" mt={2} color="red100">
+            {this.state.errorMessage}
+          </Text>
         </div>
       )
     }
 
-    return children
+    return this.props.children
   }
 }

--- a/src/system/index.ts
+++ b/src/system/index.ts
@@ -57,3 +57,15 @@ export const isPermitted = (
     )
   })
 }
+
+export const assertPermitted = (
+  user: UserWithAccessToken,
+  action: Action,
+  domain: Domain
+) => {
+  if (!isPermitted(user, [action], domain)) {
+    const permittedRoles = PERMISSIONS[domain][action] || []
+    const message = `Unauthorized: ${domain} (${Action[action]}) requires roles: ${permittedRoles}`
+    throw new Error(message)
+  }
+}

--- a/src/system/index.ts
+++ b/src/system/index.ts
@@ -65,7 +65,11 @@ export const assertPermitted = (
 ) => {
   if (!isPermitted(user, [action], domain)) {
     const permittedRoles = PERMISSIONS[domain][action] || []
-    const message = `Unauthorized: ${domain} (${Action[action]}) requires roles: ${permittedRoles}`
+    const message = `Unauthorized: ${domain} (${
+      Action[action]
+    }) requires roles: ${permittedRoles.join(
+      ", "
+    )}. Please contact your product team for assistance.`
     throw new Error(message)
   }
 }


### PR DESCRIPTION
Here's my attempt to support pages' easily asserting that the authenticated user is authorized. E.g., a user navigating directly to `/shortcuts` should get a meaningful message stating that they don't have the necessary privilege (`content_manager`) rather than encounter mysterious errors when hitting the API.

My [reading](https://nextjs.org/docs/advanced-features/error-handling) indicates that the right way to do this is to embed components in an `ErrorBoundary` like [we already do](https://github.com/artsy/forque/blob/0682e1b57bcec82ecce5e4f50b7f2205eccec920/src/pages/_app.page.tsx#L32). Throwing within an individual page component (like e.g. shortcuts/index) is supposed to be caught and handled at the boundary. The development experience is OK enough:

<img width="1093" alt="Screen Shot 2022-05-17 at 4 19 15 PM" src="https://user-images.githubusercontent.com/28120/168911071-62784bb1-236b-4320-836c-43459d0439fd.png">

But the production experience is unhelpful. The error message is only visible in the browser console, and links to [this documentation](https://nextjs.org/docs/messages/client-side-exception-occurred) indicating that the error somehow wasn't within the error boundary:

<img width="703" alt="Screen Shot 2022-05-17 at 4 37 17 PM" src="https://user-images.githubusercontent.com/28120/168911077-cf47fce5-3f1a-4750-96f1-f288bbdb65ef.png">

