### PR TITLE
chore: disable sentry performance monitoring

### DIFF
--- a/sentry.client.config.js
+++ b/sentry.client.config.js
@@ -6,9 +6,6 @@ import * as Sentry from '@sentry/nextjs';
 
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
-  // Adjust this value in production, or use tracesSampler for greater control
-  tracesSampleRate: 1.0,
-  // ...
   // Note: if you want to override the automatic release value, do not set a
   // `release` value here - use the environment variable `SENTRY_RELEASE`, so
   // that it will also get attached to your source maps

--- a/sentry.server.config.js
+++ b/sentry.server.config.js
@@ -6,9 +6,6 @@ import * as Sentry from '@sentry/nextjs';
 
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN, 
-  // Adjust this value in production, or use tracesSampler for greater control
-  tracesSampleRate: 1.0,
-  // ...
   // Note: if you want to override the automatic release value, do not set a
   // `release` value here - use the environment variable `SENTRY_RELEASE`, so
   // that it will also get attached to your source maps


### PR DESCRIPTION
This PR disables Sentry performance monitoring. We use Datadog for performance monitoring and this is causing us to bump up against our Sentry transaction threshold. 

Relevant slack discussion [here](https://artsy.slack.com/archives/C02BC3HEJ/p1652949637914639).