### PR TITLE
feat(table): Add expandable row feature

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "react-dom": "^18.0.0",
     "react-relay": "^13.2.0",
     "react-relay-network-modern": "^6.2.1",
-    "react-table": "^7.7.0",
+    "react-table": "^7.8.0",
     "regenerator-runtime": "^0.13.9",
     "relay-runtime": "^13.2.0",
     "styled-components": "^5.3.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11428,10 +11428,10 @@ react-syntax-highlighter@^13.5.3:
     prismjs "^1.21.0"
     refractor "^3.1.0"
 
-react-table@^7.7.0:
-  version "7.7.0"
-  resolved "https://registry.yarnpkg.com/react-table/-/react-table-7.7.0.tgz#e2ce14d7fe3a559f7444e9ecfe8231ea8373f912"
-  integrity sha512-jBlj70iBwOTvvImsU9t01LjFjy4sXEtclBovl3mTiqjz23Reu0DKnRza4zlLtOPACx6j2/7MrQIthIK1Wi+LIA==
+react-table@^7.8.0:
+  version "7.8.0"
+  resolved "https://registry.yarnpkg.com/react-table/-/react-table-7.8.0.tgz#07858c01c1718c09f7f1aed7034fcfd7bda907d2"
+  integrity sha512-hNaz4ygkZO4bESeFfnfOft73iBUj8K5oKi1EcSHPAibEydfsX2MyU6Z8KCr3mv3C9Kqqh71U+DhZkFvibbnPbA==
 
 react-textarea-autosize@^8.3.0:
   version "8.3.3"


### PR DESCRIPTION
This adds support for expandable rows on click. API:

```tsx
        <Table
          columns={[
            {
              Header: "Foo",
              accessor: "fooID",
            },
            {
              Header: "Bar",
              accessor: "barID",
            },
          ]}
          data={someData}
          renderExpandedRow={(row) => {
            return <div>ive expanded!!!</div>
          }}
          onRowClick={(row) => {
            row.toggleExpandRow()
          }}
        />
```