### PR TITLE
feat(feature-flags): Add confirm for delete

### DIFF
--- a/src/pages/feature-flags/components/FeatureFlagsTable.tsx
+++ b/src/pages/feature-flags/components/FeatureFlagsTable.tsx
@@ -175,27 +175,33 @@ const DeleteButton: React.FC<{
   onDelete: () => Promise<void>
 }> = ({ name, onDelete }) => {
   const { sendToast } = useToasts()
+  const [showConfirmMessage, setShowConfirmMessage] = useState(false)
   const [isDeleting, setIsDeleting] = useState(false)
 
   return (
     <Button
       size="small"
       variant="secondaryOutline"
+      width={80}
       loading={isDeleting}
       onClick={async (event) => {
         event.stopPropagation()
         event.preventDefault()
 
-        setIsDeleting(true)
-        await onDelete()
+        setShowConfirmMessage(true)
 
-        sendToast({
-          message: `Successfully archived ${name}`,
-          variant: "alert",
-        })
+        if (showConfirmMessage) {
+          setIsDeleting(true)
+          await onDelete()
+
+          sendToast({
+            message: `Successfully archived ${name}`,
+            variant: "alert",
+          })
+        }
       }}
     >
-      Delete
+      {showConfirmMessage ? "OK?" : "Delete"}
     </Button>
   )
 }


### PR DESCRIPTION
Wanted to add a small speed-bump before we can delete. On click, update the label. 

![confirm](https://user-images.githubusercontent.com/236943/173498347-244d50e5-b407-478a-aa2e-f56e6ded95c4.gif)

