### PR TITLE
feat: assert permitted for verifications

### DIFF
--- a/src/pages/verifications/index.page.tsx
+++ b/src/pages/verifications/index.page.tsx
@@ -1,8 +1,14 @@
 import Head from "next/head"
 import { Tab, Tabs } from "@artsy/palette"
 import { VarificationCreate } from "./components/VerificationCreate"
+import { useSession } from "next-auth/react"
+import { Action, assertPermitted, UserWithAccessToken } from "system"
 
 const VerificationsPage: React.FC = () => {
+  const session = useSession()
+  const user = session.data?.user as UserWithAccessToken
+  assertPermitted(user, Action.list, "verifications")
+
   return (
     <>
       <Head>


### PR DESCRIPTION
This PR follows #208 and enforces `role` permissions when a user navigates directly to `/verifications`. 