### PR TITLE
fix(storybook): get Storybook server working again

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -21,6 +21,15 @@ module.exports = {
   },
   "webpackFinal": (config) => {
     /**
+     * Allows project-relative absolute imports to work
+     * @see https://github.com/storybookjs/storybook/issues/11639#issuecomment-689835701
+     */
+     config.resolve.modules = [
+      ...config.resolve.modules,
+      path.resolve(__dirname, "..", "src"),
+    ]
+
+    /**
      * Add support for alias-imports
      * @see https://github.com/storybookjs/storybook/issues/11989#issuecomment-715524391
      */

--- a/src/components/GlobalNav.tsx
+++ b/src/components/GlobalNav.tsx
@@ -111,7 +111,7 @@ const Item: FC<{ href: string; onClick?: () => void }> = ({
 }) => {
   const router = useRouter()
   const active =
-    href === "/" ? router.pathname === "/" : router.pathname.startsWith(href)
+    href === "/" ? router?.pathname === "/" : router?.pathname?.startsWith(href)
 
   return (
     <Box onClick={onClick}>


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/PLATFORM-4240

Slack thread: https://artsy.slack.com/archives/C0376CFU527/p1655401885865179

We have Storybook set up for isolated component development within Forque. 

But the Storybook setup seems to have gotten broken when we enabled absolute project-relative imports in the project, e.g…

```js
import { Foo } from "system"
// as opposed to
import { Foo } from "../../system"
```

This fixes that by touching up the custom Webpack config inside of Storybook's setup. 

As well, it tweaks the existing `GlobalNav` component to work in the Storybook context, as the use of `useRouter` would otherwise cause errors trying to access a null object.

Server output of `yarn storybook`…

|Before|After|
|---|---|
|<img alt="before" src="https://user-images.githubusercontent.com/140521/174188833-11787d3b-bf82-4f2d-8f4f-7615b8c7e786.png">|<img alt="after" src="https://user-images.githubusercontent.com/140521/174188831-1282f25d-3e95-42b9-aa82-f2fe16de75de.png">|