### PR TITLE
feat: extend verification create to support name param

### DIFF
--- a/data/schema.graphql
+++ b/data/schema.graphql
@@ -14169,6 +14169,9 @@ input SendIdentityVerificationEmailMutationInput {
   # The email for the user undergoing identity verificaiton
   email: String
 
+  # The name to be used for the user undergoing identity verification
+  name: String
+
   # The user Id for the user undergoing identity verificaiton
   userID: String
 }

--- a/src/__generated__/useCreateIdentityVerificationMutation.graphql.ts
+++ b/src/__generated__/useCreateIdentityVerificationMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<fd2bdbdbda4077d28fd07e45f0728043>>
+ * @generated SignedSource<<9347b8dabc222ff66b22cdee41f03714>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -12,6 +12,7 @@ import { ConcreteRequest, Mutation } from 'relay-runtime';
 export type SendIdentityVerificationEmailMutationInput = {
   clientMutationId?: string | null;
   email?: string | null;
+  name?: string | null;
   userID?: string | null;
 };
 export type useCreateIdentityVerificationMutation$variables = {

--- a/src/pages/verifications/components/VerificationsCreate.tsx
+++ b/src/pages/verifications/components/VerificationsCreate.tsx
@@ -57,6 +57,7 @@ export const VerificationsCreate: React.FC = () => {
         {({ values, handleChange, errors }) => (
           <Form>
             <Input
+              description="Name to be associated with the verification request. This will be used instead of the name associated with the User's account, if applicable."
               placeholder="Jane Doe"
               title="Full Name"
               name="name"
@@ -74,7 +75,6 @@ export const VerificationsCreate: React.FC = () => {
               onChange={handleChange}
               value={values.email}
               error={errors.email}
-              required={true}
             />
             <Spacer my={4} />
             <Button type="submit" width="100%">

--- a/src/pages/verifications/components/VerificationsCreate.tsx
+++ b/src/pages/verifications/components/VerificationsCreate.tsx
@@ -57,7 +57,7 @@ export const VerificationsCreate: React.FC = () => {
         {({ values, handleChange, errors }) => (
           <Form>
             <Input
-              description="Name to be associated with the verification request. When provided this will be used instead of the name associated with the User's account."
+              description="Name to be associated with the verification request. When provided, this will be used instead of the name associated with the User's account."
               placeholder="Jane Doe"
               title="Full Name"
               name="name"

--- a/src/pages/verifications/components/VerificationsCreate.tsx
+++ b/src/pages/verifications/components/VerificationsCreate.tsx
@@ -41,15 +41,15 @@ export const VerificationsCreate: React.FC = () => {
               variant: "success",
               message: "Identity verification created",
             })
-          } catch (error) {
-            console.error(
-              "[forque] Error creating identity verification:",
-              error
-            )
+          } catch (err) {
+            console.error("[forque] Error creating identity verification:", err)
+
+            const error = Array.isArray(err) ? err[0] : err
 
             sendToast({
               variant: "error",
               message: "There was an error creating the identity verification",
+              description: error.message,
             })
           }
         }}
@@ -57,7 +57,7 @@ export const VerificationsCreate: React.FC = () => {
         {({ values, handleChange, errors }) => (
           <Form>
             <Input
-              description="Name to be associated with the verification request. This will be used instead of the name associated with the User's account, if applicable."
+              description="Name to be associated with the verification request. When provided this will be used instead of the name associated with the User's account."
               placeholder="Jane Doe"
               title="Full Name"
               name="name"

--- a/src/pages/verifications/components/VerificationsCreate.tsx
+++ b/src/pages/verifications/components/VerificationsCreate.tsx
@@ -11,12 +11,13 @@ export const VerificationsCreate: React.FC = () => {
 
   interface InputTypes {
     email: string
+    name: string
   }
 
   return (
     <>
       <Formik<InputTypes>
-        initialValues={{ email: "" }}
+        initialValues={{ email: "", name: "" }}
         validationSchema={Yup.object().shape({
           email: Yup.string()
             .required("A user email is required")
@@ -28,6 +29,7 @@ export const VerificationsCreate: React.FC = () => {
               variables: {
                 input: {
                   email: values.email,
+                  name: values.name,
                 },
               },
               rejectIf: (res) => {
@@ -55,6 +57,16 @@ export const VerificationsCreate: React.FC = () => {
         {({ values, handleChange, errors }) => (
           <Form>
             <Input
+              placeholder="Jane Doe"
+              title="Full Name"
+              name="name"
+              type="text"
+              onChange={handleChange}
+              value={values.name}
+              error={errors.name}
+            />
+            <Spacer my={2} />
+            <Input
               placeholder="user@example.com"
               title="Email"
               name="email"
@@ -62,6 +74,7 @@ export const VerificationsCreate: React.FC = () => {
               onChange={handleChange}
               value={values.email}
               error={errors.email}
+              required={true}
             />
             <Spacer my={4} />
             <Button type="submit" width="100%">

--- a/src/pages/verifications/components/__tests__/VerificationsCreate.spec.tsx
+++ b/src/pages/verifications/components/__tests__/VerificationsCreate.spec.tsx
@@ -22,6 +22,10 @@ jest.mock("../../mutations/useCreateIdentityVerification", () => ({
   }),
 }))
 
+afterEach(() => {
+  mockCreateIdentityVerification.mockClear()
+})
+
 it("shows a toast message when an identity verfication is created", async () => {
   mockCreateIdentityVerification.mockImplementation(() => successResponse)
 
@@ -38,6 +42,33 @@ it("shows a toast message when an identity verfication is created", async () => 
       variant: "success",
       message: "Identity verification created",
     })
+  )
+})
+
+it("sends the correct input with the mutation", async () => {
+  mockCreateIdentityVerification.mockImplementation(() => successResponse)
+
+  render(<VerificationsCreate />)
+
+  const emailInput = screen.getByPlaceholderText("user@example.com")
+  const nameInput = screen.getByPlaceholderText("Jane Doe")
+
+  fireEvent.change(emailInput, { target: { value: "human@user.com" } })
+  fireEvent.change(nameInput, { target: { value: "Human Person" } })
+
+  fireEvent.click(screen.getByRole("button"))
+
+  await waitFor(() =>
+    expect(mockCreateIdentityVerification).toHaveBeenCalledWith(
+      expect.objectContaining({
+        variables: {
+          input: {
+            email: "human@user.com",
+            name: "Human Person",
+          },
+        },
+      })
+    )
   )
 })
 


### PR DESCRIPTION
This PR adds a `name` input to the `VerificationsCreate` form and includes it with the mutation. 

### Related PRs
- #208

### Considerations
With this implementation, we will create an `IdentityVerification` record with the `name` field set to an empty string under the following conditions:

1. an admin doesn't enter a value for the `input` field
2. there is no `User` associated with the `email`

However, based on this [conversation](https://artsy.slack.com/archives/CTZA5NBB9/p1655488507521359) with trust and safety, we now understand there is a requirement to ensure we don't ever have a falsy value for `name`. I think the best approach is to  follow this PR up with a sibling change in `gravity` to send back an error when the conditions mentioned above are met, but let me know if you disagree.

### Related PR
- https://github.com/artsy/gravity/pull/15464

### On Failure
<img width="1525" alt="Screen Shot 2022-06-22 at 5 47 54 PM" src="https://user-images.githubusercontent.com/38149304/175145163-45e54e58-1470-4fc6-80d6-8a19b8316d82.png">


### On Success
<img width="1532" alt="Screen Shot 2022-06-22 at 5 48 12 PM" src="https://user-images.githubusercontent.com/38149304/175145178-387476aa-6671-4d1c-a8d9-0d080fc117c2.png">


### TODO 
- [x] Modify `identity_verification` endpoint in gravity to return error under the conditions above. 
