### PR TITLE
feat: idv list view to search idvs by user_id param in url query string

### DIFF
--- a/src/__generated__/VerificationsResultsQuery.graphql.ts
+++ b/src/__generated__/VerificationsResultsQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<58b6eee7f8f9d4eade875d9a9b79f18f>>
+ * @generated SignedSource<<09a9a5a6d5be2796457432c58e3f7e7d>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -12,6 +12,7 @@ import { ConcreteRequest, Query } from 'relay-runtime';
 import { FragmentRefs } from "relay-runtime";
 export type VerificationsResultsQuery$variables = {
   email?: string | null;
+  userId?: string | null;
 };
 export type VerificationsResultsQuery$data = {
   readonly viewer: {
@@ -29,6 +30,11 @@ var v0 = [
     "defaultValue": null,
     "kind": "LocalArgument",
     "name": "email"
+  },
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "userId"
   }
 ],
 v1 = {
@@ -144,6 +150,11 @@ return {
                 "kind": "Literal",
                 "name": "first",
                 "value": 20
+              },
+              {
+                "kind": "Variable",
+                "name": "userId",
+                "variableName": "userId"
               }
             ],
             "concreteType": "IdentityVerificationConnection",
@@ -391,16 +402,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "6504208695c10f4fbf68edd6e5c4ca9f",
+    "cacheID": "49859c41701443fbe27cf49f654c5a5b",
     "id": null,
     "metadata": {},
     "name": "VerificationsResultsQuery",
     "operationKind": "query",
-    "text": "query VerificationsResultsQuery(\n  $email: String\n) {\n  viewer {\n    ...VerificationsTable_viewer\n  }\n}\n\nfragment ListPagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment VerificationsTable_viewer on Viewer {\n  identityVerificationsConnection(first: 20, email: $email) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...ListPagination_pageCursors\n    }\n    edges {\n      node {\n        createdAt\n        email\n        internalID\n        name\n        state\n        userID\n        scanReferences {\n          createdAt\n          extractedFirstName\n          extractedLastName\n          extractedIdFailReason\n          extractedSimilarityFailReason\n          finishedAt\n          id\n          internalID\n          jumioID\n          result\n        }\n        overrides {\n          createdAt\n          newState\n          oldState\n          reason\n          userID\n          creator {\n            email\n            id\n          }\n          id\n        }\n        id\n      }\n    }\n  }\n}\n"
+    "text": "query VerificationsResultsQuery(\n  $email: String\n  $userId: String\n) {\n  viewer {\n    ...VerificationsTable_viewer\n  }\n}\n\nfragment ListPagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment VerificationsTable_viewer on Viewer {\n  identityVerificationsConnection(first: 20, email: $email, userId: $userId) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...ListPagination_pageCursors\n    }\n    edges {\n      node {\n        createdAt\n        email\n        internalID\n        name\n        state\n        userID\n        scanReferences {\n          createdAt\n          extractedFirstName\n          extractedLastName\n          extractedIdFailReason\n          extractedSimilarityFailReason\n          finishedAt\n          id\n          internalID\n          jumioID\n          result\n        }\n        overrides {\n          createdAt\n          newState\n          oldState\n          reason\n          userID\n          creator {\n            email\n            id\n          }\n          id\n        }\n        id\n      }\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "ff4e1296e6e260590af65bdbedd33f3a";
+(node as any).hash = "7a4e4d71657d74f9062118a403317d24";
 
 export default node;

--- a/src/__generated__/VerificationsTableQuery.graphql.ts
+++ b/src/__generated__/VerificationsTableQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<498a49db3de438103261be60e3c67e6d>>
+ * @generated SignedSource<<5a2671d4609302e28f4fb4315d9873bd>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -16,6 +16,7 @@ export type VerificationsTableQuery$variables = {
   email?: string | null;
   first?: number | null;
   last?: number | null;
+  userId?: string | null;
 };
 export type VerificationsTableQuery$data = {
   readonly viewer: {
@@ -53,6 +54,11 @@ var v0 = [
     "defaultValue": null,
     "kind": "LocalArgument",
     "name": "last"
+  },
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "userId"
   }
 ],
 v1 = {
@@ -192,7 +198,12 @@ return {
                 "variableName": "email"
               },
               (v3/*: any*/),
-              (v4/*: any*/)
+              (v4/*: any*/),
+              {
+                "kind": "Variable",
+                "name": "userId",
+                "variableName": "userId"
+              }
             ],
             "concreteType": "IdentityVerificationConnection",
             "kind": "LinkedField",
@@ -439,16 +450,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "86e55e81660cf74cb7271fff490984d8",
+    "cacheID": "a19f2b662646846319c7f1c30d6c024a",
     "id": null,
     "metadata": {},
     "name": "VerificationsTableQuery",
     "operationKind": "query",
-    "text": "query VerificationsTableQuery(\n  $after: String\n  $before: String\n  $email: String\n  $first: Int = 20\n  $last: Int\n) {\n  viewer {\n    ...VerificationsTable_viewer_pbnwq\n  }\n}\n\nfragment ListPagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment VerificationsTable_viewer_pbnwq on Viewer {\n  identityVerificationsConnection(first: $first, last: $last, after: $after, before: $before, email: $email) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...ListPagination_pageCursors\n    }\n    edges {\n      node {\n        createdAt\n        email\n        internalID\n        name\n        state\n        userID\n        scanReferences {\n          createdAt\n          extractedFirstName\n          extractedLastName\n          extractedIdFailReason\n          extractedSimilarityFailReason\n          finishedAt\n          id\n          internalID\n          jumioID\n          result\n        }\n        overrides {\n          createdAt\n          newState\n          oldState\n          reason\n          userID\n          creator {\n            email\n            id\n          }\n          id\n        }\n        id\n      }\n    }\n  }\n}\n"
+    "text": "query VerificationsTableQuery(\n  $after: String\n  $before: String\n  $email: String\n  $first: Int = 20\n  $last: Int\n  $userId: String\n) {\n  viewer {\n    ...VerificationsTable_viewer_pbnwq\n  }\n}\n\nfragment ListPagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment VerificationsTable_viewer_pbnwq on Viewer {\n  identityVerificationsConnection(first: $first, last: $last, after: $after, before: $before, email: $email, userId: $userId) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...ListPagination_pageCursors\n    }\n    edges {\n      node {\n        createdAt\n        email\n        internalID\n        name\n        state\n        userID\n        scanReferences {\n          createdAt\n          extractedFirstName\n          extractedLastName\n          extractedIdFailReason\n          extractedSimilarityFailReason\n          finishedAt\n          id\n          internalID\n          jumioID\n          result\n        }\n        overrides {\n          createdAt\n          newState\n          oldState\n          reason\n          userID\n          creator {\n            email\n            id\n          }\n          id\n        }\n        id\n      }\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "fd2924d47145c95e327970fc74e996ed";
+(node as any).hash = "810d0585b22a6b9aa9cc9ea73ed22b10";
 
 export default node;

--- a/src/__generated__/VerificationsTable_viewer.graphql.ts
+++ b/src/__generated__/VerificationsTable_viewer.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<ff581db2020c896dc3ac2e2dfff4f8f7>>
+ * @generated SignedSource<<ef116af060edf116ffff65df5008ba71>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -113,6 +113,10 @@ return {
       "defaultValue": null,
       "kind": "LocalArgument",
       "name": "last"
+    },
+    {
+      "kind": "RootArgument",
+      "name": "userId"
     }
   ],
   "kind": "Fragment",
@@ -154,6 +158,11 @@ return {
           "kind": "Variable",
           "name": "last",
           "variableName": "last"
+        },
+        {
+          "kind": "Variable",
+          "name": "userId",
+          "variableName": "userId"
         }
       ],
       "concreteType": "IdentityVerificationConnection",
@@ -366,6 +375,6 @@ return {
 };
 })();
 
-(node as any).hash = "fd2924d47145c95e327970fc74e996ed";
+(node as any).hash = "810d0585b22a6b9aa9cc9ea73ed22b10";
 
 export default node;

--- a/src/pages/verifications/components/VerificationsList.tsx
+++ b/src/pages/verifications/components/VerificationsList.tsx
@@ -2,10 +2,14 @@ import { Button, Input, Spacer } from "@artsy/palette"
 import { useState } from "react"
 import { Form, Formik } from "formik"
 import * as Yup from "yup"
+import { useRouter } from "next/router"
 import { VerificationsResults } from "./VerificationsResults"
 
 export const VerificationsList: React.FC = () => {
   const [email, setEmail] = useState("")
+
+  const router = useRouter()
+  const [userId, setUserId] = useState(router.query.user_id)
 
   interface InputTypes {
     emailInput: string
@@ -18,6 +22,7 @@ export const VerificationsList: React.FC = () => {
           emailInput: "",
         }}
         onSubmit={({ emailInput }) => {
+          setUserId("")
           setEmail(emailInput)
         }}
         validateOnChange={true}
@@ -47,7 +52,9 @@ export const VerificationsList: React.FC = () => {
           )
         }}
       </Formik>
-      {!!email && <VerificationsResults email={email} />}
+      {(!!email || !!userId) && (
+        <VerificationsResults email={email} userId={userId} />
+      )}
     </>
   )
 }

--- a/src/pages/verifications/components/VerificationsList.tsx
+++ b/src/pages/verifications/components/VerificationsList.tsx
@@ -9,7 +9,7 @@ export const VerificationsList: React.FC = () => {
   const [email, setEmail] = useState("")
 
   const router = useRouter()
-  const [userId, setUserId] = useState(router.query.user_id)
+  const [userId, setUserId] = useState(router.query.user_id as string)
 
   interface InputTypes {
     emailInput: string

--- a/src/pages/verifications/components/VerificationsList.tsx
+++ b/src/pages/verifications/components/VerificationsList.tsx
@@ -9,7 +9,7 @@ export const VerificationsList: React.FC = () => {
   const [email, setEmail] = useState("")
 
   const router = useRouter()
-  const [userId, setUserId] = useState(router.query.user_id as string)
+  const [userId, setUserId] = useState(router.query.userId as string)
 
   interface InputTypes {
     emailInput: string

--- a/src/pages/verifications/components/VerificationsResults.tsx
+++ b/src/pages/verifications/components/VerificationsResults.tsx
@@ -5,28 +5,34 @@ import { VerificationsTable } from "./VerificationsTable"
 
 interface VerificationsResultsProps {
   email: string
+  userId: string
 }
 
 export const VerificationsResults: React.FC<VerificationsResultsProps> = (
   props
 ) => {
   const email = props.email
+  const userId = props.userId
 
   const viewerData = useLazyLoadQuery<VerificationsResultsQuery>(
     graphql`
-      query VerificationsResultsQuery($email: String) {
+      query VerificationsResultsQuery($email: String, $userId: String) {
         viewer {
           ...VerificationsTable_viewer
         }
       }
     `,
-    { email },
+    { email, userId },
     { fetchPolicy: "network-only" }
   )
 
   return (
     <>
-      <VerificationsTable viewer={viewerData.viewer!} email={email} />
+      <VerificationsTable
+        viewer={viewerData.viewer!}
+        email={email}
+        userId={userId}
+      />
     </>
   )
 }

--- a/src/pages/verifications/components/VerificationsTable.tsx
+++ b/src/pages/verifications/components/VerificationsTable.tsx
@@ -9,6 +9,7 @@ import { VerificationsDetails } from "./VerificationsDetails"
 interface VerificationsTableProps {
   viewer: VerificationsTable_viewer$key
   email: string
+  userId: string
 }
 
 export const VerificationsTable: React.FC<VerificationsTableProps> = (
@@ -30,6 +31,7 @@ export const VerificationsTable: React.FC<VerificationsTableProps> = (
           after: $after
           before: $before
           email: $email
+          userId: $userId
         ) {
           pageInfo {
             hasNextPage
@@ -87,7 +89,11 @@ export const VerificationsTable: React.FC<VerificationsTableProps> = (
     <>
       <Spacer my={2} />
       <Text variant="xl" mb={4}>
-        {props.email}
+        {!!props.email && props.email}
+      </Text>
+      <Spacer my={2} />
+      <Text variant="xl" mb={4}>
+        {!!props.userId && props.userId}
       </Text>
       {!verifications.length && (
         <Text variant="xl" mb={4}>


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/PLATFORM-4095

Extend Verifications List view so that:

- If `user_id` param exists in URL query string, search Identity Verifications by it.
- Present the results and, as before, present the form for search by email.
- If user searches by email, present the new results, but the route (which has `user_id` param) does _not_ change. It seems good to clear `user_id` param when user has searched by email, but we will not concern ourselves with that for now.
- The route also does _not_ change between tab transitions (List<->Create)

No tests for this change since the changes are in top-level components that are still [pending relay testing support](https://github.com/artsy/forque/pull/226#issuecomment-1159014041).