### PR TITLE
feat (uploads): create separate success behavior for batch upload completion

### DIFF
--- a/src/pages/uploads/components/BatchUploadResult.tsx
+++ b/src/pages/uploads/components/BatchUploadResult.tsx
@@ -1,5 +1,4 @@
-import { Box, CheckCircleIcon, Spacer, Text, XCircleIcon } from "@artsy/palette"
-import Link from "next/link"
+import { Box, CheckCircleIcon, Text, XCircleIcon } from "@artsy/palette"
 import { FC } from "react"
 
 interface BatchResultProps {
@@ -9,8 +8,6 @@ interface BatchResultProps {
 export const BatchUploadResult: FC<BatchResultProps> = ({ results }) => {
   return (
     <>
-      <Spacer mt={4} />
-
       {results.map((result, i) => (
         <Box
           key={i}
@@ -22,9 +19,12 @@ export const BatchUploadResult: FC<BatchResultProps> = ({ results }) => {
         >
           {result.status === "success" ? (
             <>
-              <Link href={`/uploads/${encodeURIComponent(result.key)}`}>
+              <a
+                href={`/uploads/${encodeURIComponent(result.key)}`}
+                target="_blank noreferrer"
+              >
                 {result.key}
-              </Link>
+              </a>
               <CheckCircleIcon />
             </>
           ) : (

--- a/src/pages/uploads/components/BatchUploadResult.tsx
+++ b/src/pages/uploads/components/BatchUploadResult.tsx
@@ -1,0 +1,40 @@
+import { Box, CheckCircleIcon, Spacer, Text, XCircleIcon } from "@artsy/palette"
+import Link from "next/link"
+import { FC } from "react"
+
+interface BatchResultProps {
+  results: { key: string; status: "success" | "fail" }[]
+}
+
+export const BatchUploadResult: FC<BatchResultProps> = ({ results }) => {
+  return (
+    <>
+      <Spacer mt={4} />
+
+      {results.map((result, i) => (
+        <Box
+          key={i}
+          display="flex"
+          flexDirection="row"
+          mt={2}
+          alignItems="center"
+          justifyContent="space-between"
+        >
+          {result.status === "success" ? (
+            <>
+              <Link href={`/uploads/${encodeURIComponent(result.key)}`}>
+                {result.key}
+              </Link>
+              <CheckCircleIcon />
+            </>
+          ) : (
+            <>
+              <Text>{result.key}</Text>
+              <XCircleIcon />
+            </>
+          )}
+        </Box>
+      ))}
+    </>
+  )
+}

--- a/src/pages/uploads/components/UploadButton.tsx
+++ b/src/pages/uploads/components/UploadButton.tsx
@@ -1,6 +1,6 @@
 import { Box, Button, Spacer } from "@artsy/palette"
-import Link from "next/link"
 import { useRouter } from "next/router"
+import { BatchUploadResult } from "pages/uploads/components/BatchUploadResult"
 import { ChangeEvent, useCallback, useEffect, useState } from "react"
 import styled from "styled-components"
 import { Uploader } from "./Uploader"
@@ -10,9 +10,9 @@ export const UploadButton = () => {
 
   const [files, setFiles] = useState<File[] | null>(null)
 
-  const [uploads, setUploads] = useState<{ key: string; complete: boolean }[]>(
-    []
-  )
+  const [uploadResults, setUploadResults] = useState<
+    { key: string; status: "success" | "fail" }[]
+  >([])
 
   const router = useRouter()
 
@@ -23,19 +23,19 @@ export const UploadButton = () => {
   }
 
   const handleUploadDone = useCallback(
-    (key: string) => {
-      setUploads((prevState) => [...prevState, { key, complete: true }])
+    (key: string, status: "success" | "fail") => {
+      setUploadResults((prevState) => [...prevState, { key, status }])
     },
-    [setUploads]
+    [setUploadResults]
   )
 
   useEffect(() => {
-    if (files?.length === uploads?.length && files?.length === 1) {
-      router.push(`/uploads/${encodeURIComponent(uploads[0].key)}`)
-    } else if (files?.length === uploads?.length && files?.length > 1) {
+    if (files?.length === uploadResults?.length && files?.length === 1) {
+      router.push(`/uploads/${encodeURIComponent(uploadResults[0].key)}`)
+    } else if (files?.length === uploadResults?.length && files?.length > 1) {
       setDisplayBatch(true)
     }
-  }, [files, router, uploads])
+  }, [files, router, uploadResults])
 
   return (
     <>
@@ -62,21 +62,7 @@ export const UploadButton = () => {
         </>
       )}
 
-      {displayBatch && (
-        <>
-          <Spacer mt={4} />
-
-          {uploads.map((upload, i) => (
-            <>
-              <Link key={i} href={`/uploads/${encodeURIComponent(upload.key)}`}>
-                {upload.key}
-              </Link>
-
-              <Spacer mt={1} />
-            </>
-          ))}
-        </>
-      )}
+      {displayBatch && <BatchUploadResult results={uploadResults} />}
     </>
   )
 }

--- a/src/pages/uploads/components/UploadButton.tsx
+++ b/src/pages/uploads/components/UploadButton.tsx
@@ -62,6 +62,8 @@ export const UploadButton = () => {
         </>
       )}
 
+      <Spacer mt={4} />
+
       {displayBatch && <BatchUploadResult results={uploadResults} />}
     </>
   )

--- a/src/pages/uploads/components/Uploader.tsx
+++ b/src/pages/uploads/components/Uploader.tsx
@@ -8,7 +8,7 @@ import { useRouter } from "next/router"
 
 interface UploaderProps {
   file: File
-  onUploadDone: (key: string) => void
+  onUploadDone: (key: string, status: "success" | "fail") => void
 }
 
 export const Uploader: FC<UploaderProps> = ({
@@ -38,13 +38,11 @@ export const Uploader: FC<UploaderProps> = ({
 
     uploading.current = true
 
-    setProgress(100)
-
     uploadFile({
       file,
       presignedPost: data,
       onFileDone: () => {
-        handleUploadDone(data.fields.key)
+        handleUploadDone(data.fields.key, "success")
 
         sendToast({ variant: "success", message: "File uploaded" })
       },
@@ -52,6 +50,8 @@ export const Uploader: FC<UploaderProps> = ({
         console.error(err)
 
         sendToast({ variant: "error", message: err.message })
+
+        handleUploadDone(data.fields.key, "fail")
 
         uploading.current = false
       },

--- a/src/pages/uploads/components/Uploader.tsx
+++ b/src/pages/uploads/components/Uploader.tsx
@@ -8,9 +8,13 @@ import { useRouter } from "next/router"
 
 interface UploaderProps {
   file: File
+  onUploadDone: (key: string) => void
 }
 
-export const Uploader: FC<UploaderProps> = ({ file }) => {
+export const Uploader: FC<UploaderProps> = ({
+  file,
+  onUploadDone: handleUploadDone,
+}) => {
   const key = generateKey({ name: file.name, contentType: file.type })
 
   const { sendToast } = useToasts()
@@ -34,11 +38,13 @@ export const Uploader: FC<UploaderProps> = ({ file }) => {
 
     uploading.current = true
 
+    setProgress(100)
+
     uploadFile({
       file,
       presignedPost: data,
       onFileDone: () => {
-        router.push(`/uploads/${encodeURIComponent(data.fields.key)}`)
+        handleUploadDone(data.fields.key)
 
         sendToast({ variant: "success", message: "File uploaded" })
       },
@@ -53,7 +59,7 @@ export const Uploader: FC<UploaderProps> = ({ file }) => {
         setProgress(progress)
       },
     })
-  }, [data, file, router, sendToast])
+  }, [data, file, handleUploadDone, router, sendToast])
 
   if (!data)
     return (


### PR DESCRIPTION
The behavior for a single successful file upload is to navigate to view the uploaded file. In the case of a batch upload, we had no defined alternative.

This PR creates the logic to determine whether a single or multiple files were uploaded, and in the case of a batch upload, displays a list of links to the uploaded files. In the case that an upload failed, the display will show only text for the failed item, along with an icon to indicate which items in the batch failed. 

![Screen Shot 2022-06-21 at 8 56 58 PM](https://user-images.githubusercontent.com/14044896/174922507-be58cb07-1669-498e-b50f-4bcd43ac216c.png)