### PR TITLE
feat(dedupe): commit artist merge mutation via MP

### DIFF
--- a/src/__generated__/useMergeArtistsMutation.graphql.ts
+++ b/src/__generated__/useMergeArtistsMutation.graphql.ts
@@ -1,0 +1,243 @@
+/**
+ * @generated SignedSource<<bd9e5c38aea42c4ff35de65dc3ffd02d>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest, Mutation } from 'relay-runtime';
+export type MergeArtistsMutationInput = {
+  badIds: ReadonlyArray<string>;
+  clientMutationId?: string | null;
+  goodId: string;
+};
+export type useMergeArtistsMutation$variables = {
+  input: MergeArtistsMutationInput;
+};
+export type useMergeArtistsMutation$data = {
+  readonly mergeArtists: {
+    readonly mergeArtistsResponseOrError: {
+      readonly __typename: "MergeArtistsSuccess";
+      readonly artist: {
+        readonly internalID: string;
+        readonly slug: string;
+        readonly name: string | null;
+      } | null;
+    } | {
+      readonly __typename: "MergeArtistsFailure";
+      readonly mutationError: {
+        readonly message: string;
+      } | null;
+    } | {
+      // This will never be '%other', but we need some
+      // value in case none of the concrete values match.
+      readonly __typename: "%other";
+    } | null;
+  } | null;
+};
+export type useMergeArtistsMutation = {
+  variables: useMergeArtistsMutation$variables;
+  response: useMergeArtistsMutation$data;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "input"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "input",
+    "variableName": "input"
+  }
+],
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "__typename",
+  "storageKey": null
+},
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "internalID",
+  "storageKey": null
+},
+v4 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "slug",
+  "storageKey": null
+},
+v5 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v6 = {
+  "kind": "InlineFragment",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "GravityMutationError",
+      "kind": "LinkedField",
+      "name": "mutationError",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "message",
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    }
+  ],
+  "type": "MergeArtistsFailure",
+  "abstractKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "useMergeArtistsMutation",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "MergeArtistsMutationPayload",
+        "kind": "LinkedField",
+        "name": "mergeArtists",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": null,
+            "kind": "LinkedField",
+            "name": "mergeArtistsResponseOrError",
+            "plural": false,
+            "selections": [
+              (v2/*: any*/),
+              {
+                "kind": "InlineFragment",
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "Artist",
+                    "kind": "LinkedField",
+                    "name": "artist",
+                    "plural": false,
+                    "selections": [
+                      (v3/*: any*/),
+                      (v4/*: any*/),
+                      (v5/*: any*/)
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "type": "MergeArtistsSuccess",
+                "abstractKey": null
+              },
+              (v6/*: any*/)
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Mutation",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "useMergeArtistsMutation",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "MergeArtistsMutationPayload",
+        "kind": "LinkedField",
+        "name": "mergeArtists",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": null,
+            "kind": "LinkedField",
+            "name": "mergeArtistsResponseOrError",
+            "plural": false,
+            "selections": [
+              (v2/*: any*/),
+              {
+                "kind": "InlineFragment",
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "Artist",
+                    "kind": "LinkedField",
+                    "name": "artist",
+                    "plural": false,
+                    "selections": [
+                      (v3/*: any*/),
+                      (v4/*: any*/),
+                      (v5/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "id",
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "type": "MergeArtistsSuccess",
+                "abstractKey": null
+              },
+              (v6/*: any*/)
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "985e5de84c55a2d35dcadf26969fe4da",
+    "id": null,
+    "metadata": {},
+    "name": "useMergeArtistsMutation",
+    "operationKind": "mutation",
+    "text": "mutation useMergeArtistsMutation(\n  $input: MergeArtistsMutationInput!\n) {\n  mergeArtists(input: $input) {\n    mergeArtistsResponseOrError {\n      __typename\n      ... on MergeArtistsSuccess {\n        artist {\n          internalID\n          slug\n          name\n          id\n        }\n      }\n      ... on MergeArtistsFailure {\n        mutationError {\n          message\n        }\n      }\n    }\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "68ed4d05c62e45b11bd053ebbeaade81";
+
+export default node;

--- a/src/pages/artists/dedupe/components/manager/__tests__/ArtistDupesManager.spec.tsx
+++ b/src/pages/artists/dedupe/components/manager/__tests__/ArtistDupesManager.spec.tsx
@@ -4,6 +4,12 @@ import { render, screen } from "@testing-library/react"
 import { ArtistDupesManager } from "../ArtistDupesManager"
 import artist from "../__fixtures__/artist-with-dupes"
 
+jest.mock("next/config", () => () => ({
+  publicRuntimeConfig: {
+    NEXT_PUBLIC_GRAVITY_URL: "https://stagingapi.artsy.net",
+  },
+}))
+
 it("displays the found clusters", () => {
   render(<ArtistDupesManager artist={artist} />)
 

--- a/src/pages/artists/dedupe/components/manager/__tests__/Confirm.spec.tsx
+++ b/src/pages/artists/dedupe/components/manager/__tests__/Confirm.spec.tsx
@@ -1,22 +1,52 @@
 import React from "react"
 import { render, screen, within } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
 
 import { Confirm } from "../Confirm"
 import { State, initialState } from "../state"
 import artist from "../__fixtures__/artist-with-dupes"
 
-it("renders a card for the merged artist", () => {
-  const dispatch = jest.fn()
+jest.mock("next/config", () => () => ({
+  publicRuntimeConfig: {
+    NEXT_PUBLIC_GRAVITY_URL: "https://stagingapi.artsy.net",
+  },
+}))
 
-  const goodArtist = artist.duplicates[0]
-  const badArtist = artist.duplicates[1]
+const mockSendToast = jest.fn()
 
-  const state: State = {
-    ...initialState,
-    goodId: goodArtist.internalID,
-    badIds: [badArtist.internalID],
-  }
+jest.mock("@artsy/palette", () => ({
+  ...jest.requireActual("@artsy/palette"),
+  useToasts: () => ({
+    sendToast: mockSendToast,
+  }),
+}))
 
+const mockMergeArtistsMutation = jest.fn(() => ({
+  mergeArtists: {
+    mergeArtistsResponseOrError: {
+      artist: {
+        slug: "successfully-merged-artist",
+      },
+    },
+  },
+}))
+
+jest.mock("../../../mutations/useMergeArtists", () => ({
+  useMergeArtists: () => ({ submitMutation: mockMergeArtistsMutation }),
+}))
+
+const dispatch = jest.fn()
+
+const goodArtist = artist.duplicates[0]
+const badArtist = artist.duplicates[1]
+
+const state: State = {
+  ...initialState,
+  goodId: goodArtist.internalID,
+  badIds: [badArtist.internalID],
+}
+
+it("renders a card for the merged artist and a button to proceed", async () => {
   render(
     <Confirm
       state={{ ...state, dupes: artist.duplicates }}
@@ -33,4 +63,41 @@ it("renders a card for the merged artist", () => {
   expect(
     screen.getByRole("button", { name: "Ok, proceed" })
   ).toBeInTheDocument()
+})
+
+it("calls the mutation upon button press", async () => {
+  render(
+    <Confirm
+      state={{ ...state, dupes: artist.duplicates }}
+      dispatch={dispatch}
+    />
+  )
+
+  await userEvent.click(screen.getByRole("button", { name: "Ok, proceed" }))
+
+  expect(mockMergeArtistsMutation).toHaveBeenCalledWith({
+    variables: {
+      input: {
+        goodId: goodArtist.internalID,
+        badIds: [badArtist.internalID],
+      },
+    },
+  })
+})
+
+it("displays a toast upon success", async () => {
+  render(
+    <Confirm
+      state={{ ...state, dupes: artist.duplicates }}
+      dispatch={dispatch}
+    />
+  )
+
+  await userEvent.click(screen.getByRole("button", { name: "Ok, proceed" }))
+
+  expect(mockSendToast).toHaveBeenCalledWith(
+    expect.objectContaining({
+      message: "Artist merger succeeded",
+    })
+  )
 })

--- a/src/pages/artists/dedupe/mutations/useMergeArtists.ts
+++ b/src/pages/artists/dedupe/mutations/useMergeArtists.ts
@@ -1,0 +1,29 @@
+import { useMutation } from "hooks"
+import { graphql } from "react-relay"
+import { useMergeArtistsMutation } from "../../../../__generated__/useMergeArtistsMutation.graphql"
+
+export const useMergeArtists = () => {
+  return useMutation<useMergeArtistsMutation>({
+    mutation: graphql`
+      mutation useMergeArtistsMutation($input: MergeArtistsMutationInput!) {
+        mergeArtists(input: $input) {
+          mergeArtistsResponseOrError {
+            __typename
+            ... on MergeArtistsSuccess {
+              artist {
+                internalID
+                slug
+                name
+              }
+            }
+            ... on MergeArtistsFailure {
+              mutationError {
+                message
+              }
+            }
+          }
+        }
+      }
+    `,
+  })
+}


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/PLATFORM-4226

Follow-up to https://github.com/artsy/metaphysics/pull/4156

- Wires up the deduping UI in Forque to that^ new Metaphysics mutation
- Follows existing Forque patterns for mutation handling and toasts

## Success

<img width="50%" src="https://user-images.githubusercontent.com/140521/175334831-233aaacd-fae4-4f1e-8874-f97dedbd6cc9.gif" />

## Failure

<img width="50%" src="https://user-images.githubusercontent.com/140521/175334857-a1913e5c-5971-4345-8ff6-2f7db8d5920f.gif" />