### PR TITLE
feat(dedupe): enable field-level overrides when merging

### DIFF
--- a/data/schema.graphql
+++ b/data/schema.graphql
@@ -10282,6 +10282,29 @@ type MergeArtistsFailure {
   mutationError: GravityMutationError
 }
 
+# A map describing the field-level overrides that should be part of this merge.
+# - Each **key** is a field name such as `nationality`
+# - Each **value** is a BSON ID that indicates the artist record from which we will _prefer_ the value for the given field
+input MergeArtistsFieldOverrides {
+  # ID of the artist record that contains the `birthday` value that we want to preserve.
+  birthday: ID
+
+  # ID of the artist record that contains the `deathday` value that we want to preserve.
+  deathday: ID
+
+  # ID of the artist record that contains the `gender` value that we want to preserve.
+  gender: ID
+
+  # ID of the artist record that contains the `hometown` value that we want to preserve.
+  hometown: ID
+
+  # ID of the artist record that contains the `location` value that we want to preserve.
+  location: ID
+
+  # ID of the artist record that contains the `nationality` value that we want to preserve.
+  nationality: ID
+}
+
 input MergeArtistsMutationInput {
   # The database ID of the "bad" artist record(s), which will be **discarded** after the merge
   badIds: [String!]!
@@ -10290,6 +10313,9 @@ input MergeArtistsMutationInput {
   # The database ID of the "good" artist record, which will be **kept** after the
   # merge. Relevant fields and associations from the bad records will be merged into this one.
   goodId: String!
+
+  # A map describing the field-level overrides that should be part of this merge.
+  overrides: MergeArtistsFieldOverrides
 }
 
 type MergeArtistsMutationPayload {
@@ -10857,6 +10883,7 @@ type MyCollectionConnection {
     last: Int
     page: Int
     size: Int
+    sort: ArtistSorts
   ): ArtistConnection
   default: Boolean!
   description: String!
@@ -10939,6 +10966,7 @@ type MyCollectionInfo {
     last: Int
     page: Int
     size: Int
+    sort: ArtistSorts
   ): ArtistConnection
   default: Boolean!
   description: String!

--- a/src/__generated__/useMergeArtistsMutation.graphql.ts
+++ b/src/__generated__/useMergeArtistsMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<bd9e5c38aea42c4ff35de65dc3ffd02d>>
+ * @generated SignedSource<<6003a98053a89f4ef1a964594ee71c67>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -13,6 +13,15 @@ export type MergeArtistsMutationInput = {
   badIds: ReadonlyArray<string>;
   clientMutationId?: string | null;
   goodId: string;
+  overrides?: MergeArtistsFieldOverrides | null;
+};
+export type MergeArtistsFieldOverrides = {
+  birthday?: string | null;
+  deathday?: string | null;
+  gender?: string | null;
+  hometown?: string | null;
+  location?: string | null;
+  nationality?: string | null;
 };
 export type useMergeArtistsMutation$variables = {
   input: MergeArtistsMutationInput;

--- a/src/pages/artists/dedupe/components/manager/Confirm.tsx
+++ b/src/pages/artists/dedupe/components/manager/Confirm.tsx
@@ -5,6 +5,7 @@ import { Artist } from "../types"
 import { useMergeArtists } from "../../mutations/useMergeArtists"
 import { useToasts } from "@artsy/palette"
 import { useRouter } from "next/router"
+import _ from "lodash"
 
 interface Props {
   state: State
@@ -43,6 +44,7 @@ export const Confirm: React.FC<Props> = ({ state }) => {
                   input: {
                     goodId: state.goodId!,
                     badIds: state.badIds,
+                    overrides: _.omitBy(state.overrides, _.isEmpty),
                   },
                 },
               })

--- a/src/pages/artists/dedupe/components/manager/Confirm.tsx
+++ b/src/pages/artists/dedupe/components/manager/Confirm.tsx
@@ -5,7 +5,8 @@ import { Artist } from "../types"
 import { useMergeArtists } from "../../mutations/useMergeArtists"
 import { useToasts } from "@artsy/palette"
 import { useRouter } from "next/router"
-import _ from "lodash"
+import omitBy from "lodash/omitBy"
+import isEmpty from "lodash/isEmpty"
 
 interface Props {
   state: State
@@ -44,7 +45,7 @@ export const Confirm: React.FC<Props> = ({ state }) => {
                   input: {
                     goodId: state.goodId!,
                     badIds: state.badIds,
-                    overrides: _.omitBy(state.overrides, _.isEmpty),
+                    overrides: omitBy(state.overrides, isEmpty),
                   },
                 },
               })

--- a/src/pages/artists/dedupe/components/manager/__tests__/Confirm.spec.tsx
+++ b/src/pages/artists/dedupe/components/manager/__tests__/Confirm.spec.tsx
@@ -44,6 +44,14 @@ const state: State = {
   ...initialState,
   goodId: goodArtist.internalID,
   badIds: [badArtist.internalID],
+  overrides: {
+    gender: badArtist.internalID,
+    nationality: badArtist.internalID,
+    birthday: null,
+    deathday: null,
+    hometown: null,
+    location: null,
+  },
 }
 
 it("renders a card for the merged artist and a button to proceed", async () => {
@@ -80,6 +88,10 @@ it("calls the mutation upon button press", async () => {
       input: {
         goodId: goodArtist.internalID,
         badIds: [badArtist.internalID],
+        overrides: {
+          gender: badArtist.internalID,
+          nationality: badArtist.internalID,
+        },
       },
     },
   })


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/PLATFORM-4228

This is one of three PRs to enable the [field-level overrides](https://user-images.githubusercontent.com/140521/149867535-309f46de-dfe8-4add-99ca-42f59c2869af.gif) that are a feature of the new deduping UI.

Gravity: https://github.com/artsy/gravity/pull/15477 
Metaphysics: https://github.com/artsy/metaphysics/pull/4189
👉🏽 Forque: https://github.com/artsy/forque/pull/256

This just wires up the `override` subfields from the application state into the payload for the mutation. When it all comes together, looks like this example, where we choose to preserve the  `birthday` from one of the to-be-deleted records —

https://user-images.githubusercontent.com/140521/176051839-fece2b8e-6dbe-4e16-be63-78e725a0d87a.mov



