### PR TITLE
fix: disable feature flags in staging

### DIFF
--- a/src/pages/feature-flags/index.page.tsx
+++ b/src/pages/feature-flags/index.page.tsx
@@ -18,7 +18,7 @@ const FeatureFlagPage: React.FC<FeatureFlagPageProps> = (props) => {
   const { publicRuntimeConfig } = getConfig()
   const session = useSession()
   const user = session.data?.user as UserWithAccessToken
-  assertPermitted(user, "feature_flags")
+  assertPermitted(user, "feature-flags")
 
   // HACK: Temporary guard to prevent actions on production until a better
   // solution is implemented.

--- a/src/pages/feature-flags/index.page.tsx
+++ b/src/pages/feature-flags/index.page.tsx
@@ -1,7 +1,10 @@
-import { Tab, Tabs } from "@artsy/palette"
+import { Tab, Tabs, Banner } from "@artsy/palette"
 import { GetServerSideProps } from "next"
+import { useSession } from "next-auth/react"
+import getConfig from "next/config"
 import Head from "next/head"
 import { graphql } from "react-relay"
+import { assertPermitted, UserWithAccessToken } from "system"
 import { fetchRelayData } from "system/relay"
 import { featureFlagsQuery$data } from "__generated__/featureFlagsQuery.graphql"
 import CreateFeatureFlag from "./components/CreateFeatureFlag"
@@ -12,6 +15,18 @@ interface FeatureFlagPageProps {
 }
 
 const FeatureFlagPage: React.FC<FeatureFlagPageProps> = (props) => {
+  const { publicRuntimeConfig } = getConfig()
+  const session = useSession()
+  const user = session.data?.user as UserWithAccessToken
+  assertPermitted(user, "feature_flags")
+
+  // HACK: Temprary guard to prevent taking action against production until a
+  // better solution is implemented.
+  if (publicRuntimeConfig.NEXT_PUBLIC_METAPHYSICS_URL.includes("staging")) {
+    return (
+      <Banner variant="error">Feature Flags not available on staging</Banner>
+    )
+  }
   return (
     <>
       <Head>

--- a/src/pages/feature-flags/index.page.tsx
+++ b/src/pages/feature-flags/index.page.tsx
@@ -20,8 +20,8 @@ const FeatureFlagPage: React.FC<FeatureFlagPageProps> = (props) => {
   const user = session.data?.user as UserWithAccessToken
   assertPermitted(user, "feature_flags")
 
-  // HACK: Temprary guard to prevent taking action against production until a
-  // better solution is implemented.
+  // HACK: Temporary guard to prevent actions on production until a better
+  // solution is implemented.
   if (publicRuntimeConfig.NEXT_PUBLIC_METAPHYSICS_URL.includes("staging")) {
     return (
       <Banner variant="error">Feature Flags not available on staging</Banner>


### PR DESCRIPTION
This PR is a temporary hack to disable feature flags on staging. Relevant slack discussion [here](https://artsy.slack.com/archives/C02BC3HEJ/p1656452065764349). 

https://user-images.githubusercontent.com/38149304/176516441-bc0fb1bd-3b99-43aa-8b0f-518f7492ef50.mov



