### PR TITLE
feat(dedupe): add direct artist selection; release tool to authorized users

### DIFF
--- a/src/components/GlobalNav.tsx
+++ b/src/components/GlobalNav.tsx
@@ -34,11 +34,11 @@ export const GlobalNav: FC<GlobalNavProps> = ({ user }) => {
             <Item href="/">Home</Item>
             {/* {isPermitted(user, [Action.list], "users") && (
               <Item href="/users">Users</Item>
-            )}
-
-            {isPermitted(user, [Action.dedupe], "artists") && (
-              <Item href="/artists/dedupe">Dedupe Artists</Item>
             )} */}
+
+            {isPermitted(user, "artists") && (
+              <Item href="/artists/dedupe">Dedupe Artists</Item>
+            )}
 
             {isPermitted(user, "feature_flags") && (
               <Item href="/feature-flags">Feature Flags</Item>

--- a/src/pages/artists/dedupe/__tests__/index.spec.tsx
+++ b/src/pages/artists/dedupe/__tests__/index.spec.tsx
@@ -1,0 +1,28 @@
+import { screen } from "@testing-library/react"
+import { Role } from "system"
+import { renderWithRoles } from "test-utils"
+import Page from "../index.page"
+
+jest.mock("next/config", () => () => ({
+  publicRuntimeConfig: {},
+}))
+
+jest.mock("hooks", () => ({
+  useMetaphysics: () => ({}),
+  useGravity: () => ({ data: [] }),
+}))
+
+it("renders an autocomplete for selecting an artist", () => {
+  renderWithRoles(<Page />, [Role.metadata_admin])
+
+  expect(screen.getByText(/Choose an artist record/)).toBeInTheDocument()
+  expect(screen.getByPlaceholderText("Artist name")).toBeInTheDocument()
+})
+
+it("renders a list of recent artists", () => {
+  renderWithRoles(<Page />, [Role.metadata_admin])
+
+  expect(
+    screen.getByText(/choose from the following recent artists/)
+  ).toBeInTheDocument()
+})

--- a/src/pages/artists/dedupe/index.page.tsx
+++ b/src/pages/artists/dedupe/index.page.tsx
@@ -3,6 +3,8 @@ import { useMetaphysics } from "hooks"
 import { ArtistList, Skeleton } from "./components/list/ArtistList"
 import { useSession } from "next-auth/react"
 import { assertPermitted, UserWithAccessToken } from "system"
+import { ArtistAutocomplete } from "components/autocomplete/ArtistAutocomplete"
+import { useRouter } from "next/router"
 
 const PER_PAGE = 36
 
@@ -19,6 +21,7 @@ export default function Page() {
   const session = useSession()
   const user = session.data?.user as UserWithAccessToken
   assertPermitted(user, "artists")
+  const router = useRouter()
 
   const [page, setPage] = useState<number>(1)
 
@@ -65,8 +68,17 @@ export default function Page() {
       <h1 className="text-xxl mb-4 ">Dedupe Artists</h1>
 
       <div className="text-lg my-4">
-        Choose from the following recent artists. Potential duplicate clusters
-        are highlighted.
+        Choose an artist record in order to view and merge its potential
+        duplicate records.
+      </div>
+
+      <ArtistAutocomplete
+        onSelect={(artist) => router.push(`/artists/dedupe/${artist.value}`)}
+      />
+
+      <div className="text-lg my-4">
+        Or, choose from the following recent artists. Potential duplicate
+        clusters are highlighted.
       </div>
 
       <div className="mb-4">

--- a/src/test-utils/index.ts
+++ b/src/test-utils/index.ts
@@ -1,0 +1,1 @@
+export { renderWithRoles } from "./renderWithRoles"

--- a/src/test-utils/renderWithRoles.tsx
+++ b/src/test-utils/renderWithRoles.tsx
@@ -1,0 +1,27 @@
+import { ReactElement } from "react"
+import { SessionProvider } from "next-auth/react"
+import { render } from "@testing-library/react"
+import { Role } from "system"
+
+interface SessionWithRolesProps {
+  roles: Role[]
+}
+
+const SessionWithRoles: React.FC<SessionWithRolesProps> = (props) => {
+  const { children, roles } = props
+
+  const session = {
+    user: {
+      email: "fake.user@artsymail.com",
+      roles,
+    },
+    expires: "someday",
+  }
+
+  return <SessionProvider session={session}>{children}</SessionProvider>
+}
+
+export const renderWithRoles = (ui: ReactElement, roles: Role[]) =>
+  render(ui, {
+    wrapper: () => <SessionWithRoles roles={roles}>{ui}</SessionWithRoles>,
+  })


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/PLATFORM-4229

Two things:

- incorporate the [new artist autocomplete](https://github.com/artsy/forque/pull/59) to allow for direct selection of an artist for deduping
- launch this sucker for testing by stakeholders who have the `metadata_admin` role

Here's how it all looks, with an [example ripped from the headlines](https://artsy.slack.com/archives/C03T8CNFQ/p1656938464929029):

https://user-images.githubusercontent.com/140521/177653644-eba676ed-774d-4f7f-9ebb-8b8fcab914cc.mov


