### PR TITLE
chore(idv): reset list form after submit

### DIFF
--- a/src/pages/verifications/components/VerificationsList.tsx
+++ b/src/pages/verifications/components/VerificationsList.tsx
@@ -25,9 +25,10 @@ export const VerificationsList: React.FC<VerificationsListProps> = (props) => {
         initialValues={{
           emailInput: props.email ?? "",
         }}
-        onSubmit={({ emailInput }) => {
+        onSubmit={({ emailInput }, { resetForm }) => {
           setUserId("")
           setEmail(emailInput)
+          resetForm()
         }}
         validateOnChange={true}
         validationSchema={Yup.object().shape({


### PR DESCRIPTION
Tiny change to clear form fields after submitting a search term.

This is very similar to https://github.com/artsy/forque/commit/4f92f24e6f24dda83296a239bec5165cc22a68c4 but on the list _tab_. It occurred to me that this type of change is more of a _chore_ than a _feat_, apologies for the inconsistency in the previous commit message.